### PR TITLE
Add links for Chrome and Firefox themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,25 @@ Available now for Visual Studio Code, Hyper terminal, iTerm, Slack and Insomnia.
         <br/><br/>
         <span>Insomnia</span>
       </p>
-    </td>    
+    </td>
+    <td valign="top">
+      <p align="center">
+        <a href="https://chrome.google.com/webstore/detail/aura-theme/ddipnaombfnagpagnpdkdinoekfhfjoh">
+          <img src="https://github.com/daltonmenezes/assets/blob/master/images/icons/chrome.png?raw=true" align="center" />
+        </a>
+        <br/><br/>
+        <span>Google Chrome</span>
+      </p>
+    </td>
+    <td valign="top">
+      <p align="center">
+        <a href="https://addons.mozilla.org/en-US/firefox/addon/aura-theme">
+          <img src="https://github.com/daltonmenezes/assets/blob/master/images/icons/firefox.png?raw=true" align="center" />
+        </a>
+        <br/><br/>
+        <span>Firefox</span>
+      </p>
+    </td>
   </tr>
  </table>
 


### PR DESCRIPTION
This PR is to complete the list of themes in the README file with Chrome and Firefox themes and their respective links.

### Preview
<img width="776" alt="Screen Shot 2021-09-27 at 12 23 54" src="https://user-images.githubusercontent.com/54036572/134938058-75ead29f-c139-4bc9-b582-2eb7370c9912.png">

