### PR TITLE
feat(mattermost): add theme for mattermost

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
 :sparkles: A beautiful dark theme for your favorite apps
   <br><br>
-  
+
   <!-- Patreon -->
   <a href="https://www.patreon.com/daltonmenezes">
     <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
@@ -41,7 +41,7 @@
       <br/><br/>
       <span>Color Palettes</span>
     </p>
-  </td> 
+  </td>
   <td valign="top">
     <p align="center">
       <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/wallpapers">
@@ -50,7 +50,7 @@
       <br/><br/>
       <span>Wallpapers</span>
     </p>
-  </td> 
+  </td>
 </table>
 
 ### IDEs and Code Editors
@@ -65,7 +65,7 @@
       <br/><br/>
       <span>Visual Studio Code</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
      <p align="center">
       <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/sublime-text">
@@ -74,7 +74,7 @@
       <br/><br/>
       <span>Sublime Text</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
      <p align="center">
       <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/code-sandbox">
@@ -83,7 +83,7 @@
       <br/><br/>
       <span>CodeSandbox</span>
       </p>
-    </td>   
+    </td>
   </tr>
  </table>
 
@@ -135,7 +135,7 @@
        <br/><br/>
         <span>rxvt-unicode</span>
       </p>
-    </td> 
+    </td>
   </tr>
     <td valign="top">
       <p align="center">
@@ -145,7 +145,7 @@
        <br/><br/>
         <span>Terminal.app</span>
       </p>
-    </td> 
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/gnome-terminal">
@@ -154,7 +154,7 @@
        <br/><br/>
         <span>GNOME Terminal</span>
       </p>
-    </td> 
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/kitty">
@@ -163,7 +163,7 @@
        <br/><br/>
         <span>Kitty</span>
       </p>
-    </td> 
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/konsole">
@@ -172,7 +172,7 @@
        <br/><br/>
         <span>Konsole</span>
       </p>
-    </td> 
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/tabby">
@@ -181,7 +181,7 @@
        <br/><br/>
         <span>Tabby.sh</span>
       </p>
-    </td> 
+    </td>
   </tr>
  </table>
 
@@ -230,7 +230,7 @@
         <br/><br/>
         <span>Insomnia</span>
       </p>
-    </td>    
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/fig">
@@ -239,7 +239,7 @@
         <br/><br/>
         <span>Fig</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/telegram">
@@ -248,7 +248,7 @@
         <br/><br/>
         <span>Telegram Desktop</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/slack">
@@ -257,7 +257,7 @@
         <br/><br/>
         <span>Slack</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/icue">
@@ -266,7 +266,7 @@
         <br/><br/>
         <span>iCue</span>
       </p>
-    </td>   
+    </td>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/plasma">
@@ -275,8 +275,8 @@
         <br/><br/>
         <span>KDE Plasma</span>
       </p>
-    </td>   
-        <td valign="top">
+    </td>
+    <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/ngenuity">
           <img src="https://raw.githubusercontent.com/daltonmenezes/assets/master/images/icons/ngenuity.png" align="center" />
@@ -284,7 +284,16 @@
         <br/><br/>
         <span>NGenuity</span>
       </p>
-    </td>  
+    </td>
+    <td valign="top">
+      <p align="center">
+        <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/mattermost">
+          <img src="https://github.com/daltonmenezes/assets/blob/master/images/icons/mattermost.png?raw=true" align="center" />
+        </a>
+        <br/><br/>
+        <span>Mattermost</span>
+      </p>
+    </td>
   </tr>
  </table>
 
@@ -330,7 +339,7 @@
     </td>
   </tr>
 </table>
- 
+
 # Contributing
 > Contributions are always welcome, but always **ask first**, — please — before work on a PR.
 

--- a/packages/mattermost/README.md
+++ b/packages/mattermost/README.md
@@ -1,0 +1,35 @@
+# Installation
+In Mattermost App
+1. Open **Settings**
+2. Select **Display** from Sidebar
+3. Select **Theme** > **Edit**
+4. Select **Custom Themes**
+5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/mahendradambe/aura-theme/feat/mattermost/packages/mattermost/aura-dark.json)
+
+# Contributors
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom"><p align="center">
+        <a href="https://github.com/mahendradambe">
+          <img style="height: 100px;" src="https://github.com/mahendradambe.png?size=100" align="center" />
+        </a>
+      </p></td>
+      <td valign="bottom"><p align="center">
+  <a href="https://github.com/daltonmenezes">
+    <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
+  </a>
+</p></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/mahendradambe">Mahendra Dambe</a></td>
+      <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+    </tr>
+  </tbody>
+</table>
+
+# License
+[MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)

--- a/packages/mattermost/README.md
+++ b/packages/mattermost/README.md
@@ -28,7 +28,7 @@ In Mattermost App
 2. Select **Display** from Sidebar
 3. Select **Theme** > **Edit**
 4. Select **Custom Themes**
-5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/mahendradambe/aura-theme/feat/mattermost/packages/mattermost/aura-dark.json)
+5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/mattermost/aura-dark.json)
 
 # Contributors
 <table>

--- a/packages/mattermost/README.md
+++ b/packages/mattermost/README.md
@@ -1,3 +1,27 @@
+<p align="center">
+  <img src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/new-heading.png?raw=true" alt="Aura Theme" width="70%" />
+</p>
+
+<p align="center">
+✨ A beautiful dark theme for  and another apps
+  <br><br>
+
+  <!-- Patreon -->
+  <a href="https://www.patreon.com/daltonmenezes">
+    <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+
+  <!-- version -->
+  <a href="#">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+</p>
+
+<p align="center">
+  <img alt="preview" src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/aura-mattermost-preview.png?raw=true" />
+</p>
+
+
 # Installation
 In Mattermost App
 1. Open **Settings**
@@ -33,3 +57,4 @@ In Mattermost App
 
 # License
 [MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)
+

--- a/packages/mattermost/aura-dark.json
+++ b/packages/mattermost/aura-dark.json
@@ -1,0 +1,28 @@
+{
+    "awayIndicator": "#ffca85",
+    "buttonBg": "#a277ff",
+    "buttonColor": "#edecee",
+    "centerChannelBg": "#15141b",
+    "centerChannelColor": "#edecee",
+    "dndIndicator": "#ff6767",
+    "errorTextColor": "#ff6767",
+    "linkColor": "#82e2ff",
+    "mentionBg": "#f694ff",
+    "mentionBj": "#82e2ff",
+    "mentionColor": "#15141b",
+    "mentionHighlightBg": "#a277ff",
+    "mentionHighlightLink": "#edecee",
+    "newMessageSeparator": "#49c29a",
+    "onlineIndicator": "#9dff65",
+    "sidebarBg": "#121016",
+    "sidebarHeaderBg": "#15141b",
+    "sidebarHeaderTextColor": "#ffca85",
+    "sidebarTeamBarBg": "#121016",
+    "sidebarText": "#61ffca",
+    "sidebarTextActiveBorder": "#3ea7847f",
+    "sidebarTextActiveColor": "#61ffca",
+    "sidebarTextHoverBg": "#00d89023",
+    "sidebarUnreadText": "#edecee",
+    "codeTheme": "aura-dark"
+}
+

--- a/src/ports/mattermost/index.ts
+++ b/src/ports/mattermost/index.ts
@@ -1,0 +1,19 @@
+import { AuraAPI } from 'core'
+import { resolve } from 'path'
+
+export async function MattermostPort(Aura: AuraAPI) {
+  const { createPort, createReadme, colorSchemes } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+
+  await createPort({
+    template: resolve(templateFolder, `aura-dark.json`),
+    replacements: {
+      ...colorSchemes.dark,
+    },
+  })
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {},
+  })
+}

--- a/src/ports/mattermost/index.ts
+++ b/src/ports/mattermost/index.ts
@@ -2,7 +2,8 @@ import { AuraAPI } from 'core'
 import { resolve } from 'path'
 
 export async function MattermostPort(Aura: AuraAPI) {
-  const { createPort, createReadme, colorSchemes } = Aura
+  const { createPort, createReadme, colorSchemes, constants } = Aura
+
   const templateFolder = resolve(__dirname, 'templates')
 
   await createPort({
@@ -12,8 +13,15 @@ export async function MattermostPort(Aura: AuraAPI) {
     },
   })
 
+  const { info } = constants
+  const version = '1.0.0'
+  const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-mattermost-preview.png?raw=true`
+
   await createReadme({
     template: resolve(templateFolder, 'README.md'),
-    replacements: {},
+    replacements: {
+      previewURL,
+      version,
+    },
   })
 }

--- a/src/ports/mattermost/templates/README.md
+++ b/src/ports/mattermost/templates/README.md
@@ -6,7 +6,7 @@ In Mattermost App
 2. Select **Display** from Sidebar
 3. Select **Theme** > **Edit**
 4. Select **Custom Themes**
-5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/mahendradambe/aura-theme/feat/mattermost/packages/mattermost/aura-dark.json)
+5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/{{ author.username }}/{{ slug }}/main/packages/mattermost/aura-dark.json)
 
 # Contributors
 <table>

--- a/src/ports/mattermost/templates/README.md
+++ b/src/ports/mattermost/templates/README.md
@@ -1,3 +1,5 @@
+{{{ basic-heading }}}
+
 # Installation
 In Mattermost App
 1. Open **Settings**
@@ -28,3 +30,4 @@ In Mattermost App
 </table>
 
 {{{ footer }}}
+

--- a/src/ports/mattermost/templates/README.md
+++ b/src/ports/mattermost/templates/README.md
@@ -1,0 +1,30 @@
+# Installation
+In Mattermost App
+1. Open **Settings**
+2. Select **Display** from Sidebar
+3. Select **Theme** > **Edit**
+4. Select **Custom Themes**
+5. Copy the content from [aura-dark.json](https://raw.githubusercontent.com/mahendradambe/aura-theme/feat/mattermost/packages/mattermost/aura-dark.json)
+
+# Contributors
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom"><p align="center">
+        <a href="https://github.com/mahendradambe">
+          <img style="height: 100px;" src="https://github.com/mahendradambe.png?size=100" align="center" />
+        </a>
+      </p></td>
+      {{{ author-thead }}}
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/mahendradambe">Mahendra Dambe</a></td>
+      {{{ author-tbody }}}
+    </tr>
+  </tbody>
+</table>
+
+{{{ footer }}}

--- a/src/ports/mattermost/templates/aura-dark.json
+++ b/src/ports/mattermost/templates/aura-dark.json
@@ -1,0 +1,28 @@
+{
+    "awayIndicator": "{{accent3}}",
+    "buttonBg": "{{accent1}}",
+    "buttonColor": "{{accent7}}",
+    "centerChannelBg": "{{accent12}}",
+    "centerChannelColor": "{{accent7}}",
+    "dndIndicator": "{{accent5}}",
+    "errorTextColor": "{{accent5}}",
+    "linkColor": "{{accent32}}",
+    "mentionBg": "{{accent6}}",
+    "mentionBj": "{{accent32}}",
+    "mentionColor": "{{accent12}}",
+    "mentionHighlightBg": "{{accent1}}",
+    "mentionHighlightLink": "{{accent7}}",
+    "newMessageSeparator": "{{accent25}}",
+    "onlineIndicator": "{{accent4}}",
+    "sidebarBg": "{{accent24}}",
+    "sidebarHeaderBg": "{{accent12}}",
+    "sidebarHeaderTextColor": "{{accent3}}",
+    "sidebarTeamBarBg": "{{accent24}}",
+    "sidebarText": "{{accent2}}",
+    "sidebarTextActiveBorder": "{{accent19}}",
+    "sidebarTextActiveColor": "{{accent2}}",
+    "sidebarTextHoverBg": "{{accent26}}",
+    "sidebarUnreadText": "{{accent7}}",
+    "codeTheme": "aura-dark"
+}
+


### PR DESCRIPTION
#### Description

This PR adds a port for Mattermost using Aura Dark palette.
Closes #139 

#### Assets
<img width="1097" alt="Screenshot 2022-05-08 at 01 05 00" src="https://user-images.githubusercontent.com/45140148/167269560-805e73f4-195e-4f5f-9f3d-c0c537178813.png">
<img width="1097" alt="Screenshot 2022-05-08 at 01 13 33" src="https://user-images.githubusercontent.com/45140148/167269563-55c6be56-7230-4285-af6a-70e990755b4a.png">
<img width="1266" alt="Screenshot 2022-05-08 at 01 16 09" src="https://user-images.githubusercontent.com/45140148/167269554-f4416a9b-2ac6-4ec4-bf2f-b93e7a57bc5b.png">

![mattermost](https://user-images.githubusercontent.com/45140148/167269664-7e7acad9-fb2f-4164-a2f7-9da04c9ddff1.svg)


- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually
- [x] I've attached an image to the icon of the app that this port is related to
- [x] I've attached a screenshot with a good zoom in fullscreen showing this port in action


