### PR TITLE
feat(windows-terminal): add variants

### DIFF
--- a/packages/windows-terminal/README.md
+++ b/packages/windows-terminal/README.md
@@ -26,15 +26,21 @@
 1. Start Windows Terminal.
 2. Click on the down arrow icon and select the `Settings` option.
 3. On the left menu, select `Open JSON file`
-4. In the `settings.json` file, find the section called "Schemes" and paste the content of [aura-theme.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme.json) inside of schemes array `[ ]`.
-5. Yet in the `settings.json`file, find the profiles section and set a "colorScheme" value on the `default profile` as the following example:
-    ```json
-    "profiles": {
-        "defaults": {
-            "colorScheme": "Aura Theme"
-        }
-    }
-    ```
+4. Pick one of the themes from the list and note the name of the theme:
+   - [aura-theme.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme.json)
+   - [aura-theme-soft-text.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme-soft-text.json)
+   - [aura-theme-soft-dark.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme-soft-dark.json)
+   - [aura-theme-soft-dark-soft-text.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme-soft-dark-soft-text.json)
+5. In the `settings.json` file, find the section called "Schemes" and paste your chosen theme inside of schemes array `[ ]`.
+6. Yet in the `settings.json`file, find the profiles section and set a "colorScheme" value on the `default profile` and write the name you noted, as the following example (if you chose "Aura Dark"):
+     ```json
+     "profiles": {
+         "defaults": {
+             "colorScheme": "Aura Dark"
+         }
+     }
+     ```
+
 
 <br/>
 Done! ✨ 🎉
@@ -50,12 +56,18 @@ Done! ✨ 🎉
     <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
   </a>
 </p></td>
+      <td valign="bottom"><p align="center">
+        <a href="https://github.com/DaBultz">
+          <img src="https://github.com/DaBultz.png?size=100" align="center" />
+        </a>
+      </p></td>
     </tr>
   </thead>
 
   <tbody>
     <tr>
       <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+      <td><a href="https://github.com/DaBultz">DaBultz</a></td>
     </tr>
   </tbody>
 </table>

--- a/packages/windows-terminal/aura-theme-soft-dark-soft-text.json
+++ b/packages/windows-terminal/aura-theme-soft-dark-soft-text.json
@@ -1,0 +1,23 @@
+{
+  "name": "Aura Soft Dark (Soft Text)",
+  "cursorColor": "#8464c6",
+  "selectionBackground": "#a394f0",
+  "background": "#21202e",
+  "foreground": "#bdbdbd",
+  "black": "#1c1b22",
+  "blue": "#54c59f",
+  "cyan": "#bdbdbd",
+  "green": "#54c59f",
+  "purple": "#8464c6",
+  "red": "#c55858",
+  "white": "#bdbdbd",
+  "yellow": "#c7a06f",
+  "brightBlack": "#4d4d4d",
+  "brightBlue": "#8464c6",
+  "brightCyan": "#54c59f",
+  "brightGreen": "#8464c6",
+  "brightPurple": "#8464c6",
+  "brightRed": "#c7a06f",
+  "brightWhite": "#bdbdbd",
+  "brightYellow": "#c7a06f"
+}

--- a/packages/windows-terminal/aura-theme-soft-dark.json
+++ b/packages/windows-terminal/aura-theme-soft-dark.json
@@ -1,10 +1,10 @@
 {
-  "name": "Aura Dark",
+  "name": "Aura Soft Dark",
   "cursorColor": "#a277ff",
   "selectionBackground": "#a394f0",
-  "background": "#15141b",
+  "background": "#21202e",
   "foreground": "#edecee",
-  "black": "#110f18",
+  "black": "#1c1b22",
   "blue": "#61ffca",
   "cyan": "#edecee",
   "green": "#61ffca",

--- a/packages/windows-terminal/aura-theme-soft-text.json
+++ b/packages/windows-terminal/aura-theme-soft-text.json
@@ -1,0 +1,23 @@
+{
+  "name": "Aura Dark (Soft Text)",
+  "cursorColor": "#8464c6",
+  "selectionBackground": "#a394f0",
+  "background": "#15141b",
+  "foreground": "#bdbdbd",
+  "black": "#110f18",
+  "blue": "#54c59f",
+  "cyan": "#bdbdbd",
+  "green": "#54c59f",
+  "purple": "#8464c6",
+  "red": "#c55858",
+  "white": "#bdbdbd",
+  "yellow": "#c7a06f",
+  "brightBlack": "#4d4d4d",
+  "brightBlue": "#8464c6",
+  "brightCyan": "#54c59f",
+  "brightGreen": "#8464c6",
+  "brightPurple": "#8464c6",
+  "brightRed": "#c7a06f",
+  "brightWhite": "#bdbdbd",
+  "brightYellow": "#c7a06f"
+}

--- a/src/ports/windows-terminal/index.ts
+++ b/src/ports/windows-terminal/index.ts
@@ -19,6 +19,40 @@ export async function WindowsTerminalPort(Aura: AuraAPI) {
       ...colorSchemes.dark,
       ...info,
       accent17: fixedSelectionBackground,
+      displayName: `${info.shortName} Dark`,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.json`),
+    outputFileName: `${info.slug}-soft-text`,
+    replacements: {
+      ...colorSchemes.darkSoft,
+      ...info,
+      accent17: fixedSelectionBackground,
+      displayName: `${info.shortName} Dark (Soft Text)`,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.json`),
+    outputFileName: `${info.slug}-soft-dark`,
+    replacements: {
+      ...colorSchemes.softDark,
+      ...info,
+      accent17: fixedSelectionBackground,
+      displayName: `${info.shortName} Soft Dark`,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.json`),
+    outputFileName: `${info.slug}-soft-dark-soft-text`,
+    replacements: {
+      ...colorSchemes.softDarkSoft,
+      ...info,
+      accent17: fixedSelectionBackground,
+      displayName: `${info.shortName} Soft Dark (Soft Text)`,
     },
   })
 

--- a/src/ports/windows-terminal/templates/README.md
+++ b/src/ports/windows-terminal/templates/README.md
@@ -4,15 +4,21 @@
 1. Start {{ portName }}.
 2. Click on the down arrow icon and select the `Settings` option.
 3. On the left menu, select `Open JSON file`
-4. In the `settings.json` file, find the section called "Schemes" and paste the content of [{{ slug }}.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/aura-theme.json) inside of schemes array `[ ]`.
-5. Yet in the `settings.json`file, find the profiles section and set a "colorScheme" value on the `default profile` as the following example:
-    ```json
-    "profiles": {
-        "defaults": {
-            "colorScheme": "{{ displayName }}"
-        }
-    }
-    ```
+4. Pick one of the themes from the list and note the name of the theme:
+   - [{{ slug }}.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/{{ slug }}.json)
+   - [{{ slug }}-soft-text.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/{{ slug }}-soft-text.json)
+   - [{{ slug }}-soft-dark.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/{{ slug }}-soft-dark.json)
+   - [{{ slug }}-soft-dark-soft-text.json](https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/windows-terminal/{{ slug }}-soft-dark-soft-text.json)
+5. In the `settings.json` file, find the section called "Schemes" and paste your chosen theme inside of schemes array `[ ]`.
+6. Yet in the `settings.json`file, find the profiles section and set a "colorScheme" value on the `default profile` and write the name you noted, as the following example (if you chose "Aura Dark"):
+     ```json
+     "profiles": {
+         "defaults": {
+             "colorScheme": "{{ shortName }} Dark"
+         }
+     }
+     ```
+
 
 {{{ done }}}
 
@@ -21,12 +27,18 @@
   <thead>
     <tr>
       {{{ author-thead }}}
+      <td valign="bottom"><p align="center">
+        <a href="https://github.com/DaBultz">
+          <img src="https://github.com/DaBultz.png?size=100" align="center" />
+        </a>
+      </p></td>
     </tr>
   </thead>
 
   <tbody>
     <tr>
       {{{ author-tbody }}}
+      <td><a href="https://github.com/DaBultz">DaBultz</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
#### Description

This PR: adds the `Soft Text`, `Soft Dark` and `Soft Dark (Soft Text)` variant to windows terminal

#### Assets

<!--
If this PR is about a new port, you must provide:
  1. An image to the icon of the app that this port is related to
  2. A screenshot with a good zoom in fullscreen showing this port in action

If this PR is not about a new port: remove this "Assets" section 
-->

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [X] PR description included
- [X] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [X] I've created or commented in an issue related to this port asking to work on it
- [X] I know I shouldn't change any files in the packages folder manually
- [ ] I've added this port at the end of the related category list in the [main README](https://github.com/daltonmenezes/aura-theme/blob/main/README.md)
- [ ] I've attached an image to the icon of the app that this port is related to
- [ ] I've attached a screenshot with a good zoom in fullscreen showing this port in action
