### PR TITLE
fix: add missing opening tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@
 ### Others
 
 <table >
+  <tr>
     <td valign="top">
       <p align="center">
         <a href="https://github.com/daltonmenezes/aura-theme/tree/main/packages/insomnia">


### PR DESCRIPTION
#### Description

This PR adds a missing opening `<tr>`  tag in the README.

#### Checklist

- [X] PR description included
- [X] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [ ] I've created or commented in an issue related to this port asking to work on it
