### PR TITLE
fix(neovim): gray text in tab bar(unselected  tabs)

### DIFF
--- a/packages/neovim/lua/aura-theme/groups/editor.lua
+++ b/packages/neovim/lua/aura-theme/groups/editor.lua
@@ -29,7 +29,7 @@ local function createEditorGroup(palette, aura)
     SpellCap = aura.OrangeUnderline,
     SpellLocal = aura.BlueUnderline,
     SpellRare = aura.PurpleUnderline,
-    TabLine = { fg = palette.black, bg = palette.black },
+    TabLine = { fg = palette.gray, bg = palette.black },
     TabLineFill = { fg = palette.black, bg = palette.black },
     TabLineSel = { fg = palette.green, bg = palette.black, gui = "inverse" },
     Title = aura.GreenBold,

--- a/src/ports/neovim/extra/lua/aura-theme/groups/editor.lua
+++ b/src/ports/neovim/extra/lua/aura-theme/groups/editor.lua
@@ -29,7 +29,7 @@ local function createEditorGroup(palette, aura)
     SpellCap = aura.OrangeUnderline,
     SpellLocal = aura.BlueUnderline,
     SpellRare = aura.PurpleUnderline,
-    TabLine = { fg = palette.black, bg = palette.black },
+    TabLine = { fg = palette.gray, bg = palette.black },
     TabLineFill = { fg = palette.black, bg = palette.black },
     TabLineSel = { fg = palette.green, bg = palette.black, gui = "inverse" },
     Title = aura.GreenBold,


### PR DESCRIPTION
#### Description

The names of unselected tabs in the tabline are not visible.
I created the PR before creating the issue, because the patch is small. (sorry).

Before this PR:
![image](https://github.com/user-attachments/assets/a0d06972-fa6a-49ff-9f97-6fe7edad7f8e)

After this PR:
![image](https://github.com/user-attachments/assets/528883b8-957e-4753-967f-c1a925937ef2)


#### Checklist

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I know I shouldn't change any files in the packages folder manually
