### PR TITLE
fix(vscode): improve jsx children color

### DIFF
--- a/packages/vscode/themes/aura-dark-color-theme.json
+++ b/packages/vscode/themes/aura-dark-color-theme.json
@@ -179,7 +179,6 @@
         "variable.other.quoted.double",
         "markup.inline.raw.string.markdown",
         "entity.other.attribute-name.id.css",
-        "meta.jsx.children",
         "JSXNested"
       ],
       "settings": {
@@ -256,7 +255,8 @@
         "punctuation.section.embedded",
         "meta.embedded.expression",
         "punctuation.terminator.dart",
-        "punctuation.dot.dart"
+        "punctuation.dot.dart",
+        "meta.jsx.children"
       ],
       "settings": {
         "foreground": "#edecee"

--- a/packages/vscode/themes/aura-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-dark-soft-text-color-theme.json
@@ -179,7 +179,6 @@
         "variable.other.quoted.double",
         "markup.inline.raw.string.markdown",
         "entity.other.attribute-name.id.css",
-        "meta.jsx.children",
         "JSXNested"
       ],
       "settings": {
@@ -256,7 +255,8 @@
         "punctuation.section.embedded",
         "meta.embedded.expression",
         "punctuation.terminator.dart",
-        "punctuation.dot.dart"
+        "punctuation.dot.dart",
+        "meta.jsx.children"
       ],
       "settings": {
         "foreground": "#bdbdbd"

--- a/packages/vscode/themes/aura-soft-dark-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-color-theme.json
@@ -179,7 +179,6 @@
         "variable.other.quoted.double",
         "markup.inline.raw.string.markdown",
         "entity.other.attribute-name.id.css",
-        "meta.jsx.children",
         "JSXNested"
       ],
       "settings": {
@@ -256,7 +255,8 @@
         "punctuation.section.embedded",
         "meta.embedded.expression",
         "punctuation.terminator.dart",
-        "punctuation.dot.dart"
+        "punctuation.dot.dart",
+        "meta.jsx.children"
       ],
       "settings": {
         "foreground": "#edecee"

--- a/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
@@ -179,7 +179,6 @@
         "variable.other.quoted.double",
         "markup.inline.raw.string.markdown",
         "entity.other.attribute-name.id.css",
-        "meta.jsx.children",
         "JSXNested"
       ],
       "settings": {
@@ -256,7 +255,8 @@
         "punctuation.section.embedded",
         "meta.embedded.expression",
         "punctuation.terminator.dart",
-        "punctuation.dot.dart"
+        "punctuation.dot.dart",
+        "meta.jsx.children"
       ],
       "settings": {
         "foreground": "#bdbdbd"

--- a/src/ports/vscode/templates/theme.json
+++ b/src/ports/vscode/templates/theme.json
@@ -179,7 +179,6 @@
         "variable.other.quoted.double",
         "markup.inline.raw.string.markdown",
         "entity.other.attribute-name.id.css",
-        "meta.jsx.children",
         "JSXNested"
       ],
       "settings": {
@@ -256,7 +255,8 @@
         "punctuation.section.embedded",
         "meta.embedded.expression",
         "punctuation.terminator.dart",
-        "punctuation.dot.dart"
+        "punctuation.dot.dart",
+        "meta.jsx.children"
       ],
       "settings": {
         "foreground": "{{ accent7 }}"


### PR DESCRIPTION
#### Description

The JSX text color currently has no contrast in comparison to attributes. The current color is also inconsistent with HTML text which is already using Accent7 (instead of Accent2). Fixes a9a7f641be0d0f5d1fc0ffa170148fccb559b415 (#47).

Current JSX styling (Accent2):
![2024-09-26 15_07_16-● _div class=_class-a__ • Untitled-1 - asteroid - Visual Studio Code](https://github.com/user-attachments/assets/11beed01-0866-43a0-a65d-bcc751ec9df3)

Proposed JSX styling (Accent7):
![2024-09-26 15_07_28-● _div class=_class-a__ • Untitled-2 - asteroid - Visual Studio Code](https://github.com/user-attachments/assets/3ae55007-d403-49a0-ba7c-10c4f94ac287)

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I know I shouldn't change any files in the packages folder manually