### PR TITLE
feat(port): add vivid port

### DIFF
--- a/packages/vivid/README.md
+++ b/packages/vivid/README.md
@@ -26,37 +26,6 @@
 
 Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
 
-## Option 1: Use the version bundled with Vivid
-
-1. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from Vivid's themes:
-
-   ```sh
-   export LS_COLORS="$(vivid generate aura-theme-dark)"
-   ```
-
-   or for the Dark Soft variant:
-
-   ```sh
-   export LS_COLORS="$(vivid generate aura-theme-dark-soft)"
-   ```
-
-   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
-
-   ```sh
-   if ! command -v gls &> /dev/null; then
-     brew install coreutils
-     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
-   fi
-   ```
-
-2. Restart your terminal or source your RC file to apply the changes:
-
-   ```sh
-   source ~/.zshrc  # or source ~/.bashrc, etc.
-   ```
-
-## Option 2: Manually install the theme files
-
 1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
 
    ```sh
@@ -83,11 +52,26 @@ Ensure you have Vivid installed on your system. You can find installation instru
    export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/aura-theme-dark-soft.yml)"
    ```
 
+   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
+
+   ```sh
+   if ! command -v gls &> /dev/null; then
+     brew install coreutils
+     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
+   fi
+   ```
+
 4. Restart your terminal or source your RC file to apply the changes:
 
    ```sh
    source ~/.zshrc  # or source ~/.bashrc, etc.
    ```
+
+<br>
+
+> **A note on using Vivid's internal themes**
+>
+> Vivid comes with a set of built-in themes that you can use without needing to download any additional files. Native support within Vivid for the Aura theme may be added in the future, pending approval and an updated build by the Vivid maintainer.
 
 <br/>
 Done! ✨ 🎉

--- a/packages/vivid/README.md
+++ b/packages/vivid/README.md
@@ -1,0 +1,126 @@
+<p align="center">
+  <img src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/new-heading.png?raw=true" alt="Aura Theme" width="70%" />
+</p>
+
+<p align="center">
+✨ A beautiful dark theme for Vivid and other apps
+  <br><br>
+
+  <!-- Patreon -->
+  <a href="https://www.patreon.com/daltonmenezes">
+    <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+
+  <!-- version -->
+  <a href="#">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+</p>
+
+<p align="center">
+  <img alt="preview" src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/aura-vivid-preview.png?raw=true" />
+</p>
+
+
+# Installation
+
+Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
+
+## Option 1: Use the version bundled with Vivid
+
+1. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from Vivid's themes:
+
+   ```sh
+   export LS_COLORS="$(vivid generate aura-theme-dark)"
+   ```
+
+   or for the Dark Soft variant:
+
+   ```sh
+   export LS_COLORS="$(vivid generate aura-theme-dark-soft)"
+   ```
+
+   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
+
+   ```sh
+   if ! command -v gls &> /dev/null; then
+     brew install coreutils
+     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
+   fi
+   ```
+
+2. Restart your terminal or source your RC file to apply the changes:
+
+   ```sh
+   source ~/.zshrc  # or source ~/.bashrc, etc.
+   ```
+
+## Option 2: Manually install the theme files
+
+1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/vivid/themes
+   ```
+
+2. Fetch the `aura-theme-dark.yml` and `aura-theme-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/aura-theme) with the following command:
+
+   ```sh
+   curl -o ~/.config/vivid/themes/aura-theme-dark.yml https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/vivid/aura-theme-dark.yml
+   ```
+
+   **NOTE:** You can replace `aura-theme-dark.yml` with `aura-theme-dark-soft.yml` in the command above to download the Dark Soft variant.
+
+3. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
+
+   ```sh
+   export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/aura-theme-dark.yml)"
+   ```
+
+   or for the Dark Soft variant:
+
+   ```sh
+   export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/aura-theme-dark-soft.yml)"
+   ```
+
+4. Restart your terminal or source your RC file to apply the changes:
+
+   ```sh
+   source ~/.zshrc  # or source ~/.bashrc, etc.
+   ```
+
+<br/>
+Done! ✨ 🎉
+<br/>
+<br/>
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      <td valign="bottom"><p align="center">
+  <a href="https://github.com/daltonmenezes">
+    <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
+  </a>
+</p></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+    </tr>
+  </tbody>
+</table>
+
+# License
+[MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)

--- a/packages/vivid/README.md
+++ b/packages/vivid/README.md
@@ -66,7 +66,7 @@ Ensure you have Vivid installed on your system. You can find installation instru
 2. Fetch the `aura-theme-dark.yml` and `aura-theme-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/aura-theme) with the following command:
 
    ```sh
-   curl -o ~/.config/vivid/themes/aura-theme-dark.yml https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/vivid/aura-theme-dark.yml
+   curl -o ~/.config/vivid/themes/aura-theme-dark.yml https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/vivid/aura-theme-dark.yml
    ```
 
    **NOTE:** You can replace `aura-theme-dark.yml` with `aura-theme-dark-soft.yml` in the command above to download the Dark Soft variant.

--- a/packages/vivid/README.md
+++ b/packages/vivid/README.md
@@ -24,9 +24,9 @@
 
 # Installation
 
-Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
+Ensure you have **Vivid** installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
 
-1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
+1. Create a directory to store custom themes for **Vivid** (if it doesn't already exist):
 
    ```sh
    mkdir -p ~/.config/vivid/themes
@@ -40,7 +40,7 @@ Ensure you have Vivid installed on your system. You can find installation instru
 
    **NOTE:** You can replace `aura-theme-dark.yml` with `aura-theme-dark-soft.yml` in the command above to download the Dark Soft variant.
 
-3. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
+3. Add the Aura Theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
 
    ```sh
    export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/aura-theme-dark.yml)"
@@ -69,9 +69,9 @@ Ensure you have Vivid installed on your system. You can find installation instru
 
 <br>
 
-> **A note on using Vivid's internal themes**
+> A note on using **Vivid's** internal themes
 >
-> Vivid comes with a set of built-in themes that you can use without needing to download any additional files. Native support within Vivid for the Aura theme may be added in the future, pending approval and an updated build by the Vivid maintainer.
+> **Vivid** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Vivid** for the Aura Theme may be added in the future, pending PR approval and an updated build by the Vivid maintainer.
 
 <br/>
 Done! ✨ 🎉

--- a/packages/vivid/aura-theme-dark-soft.yml
+++ b/packages/vivid/aura-theme-dark-soft.yml
@@ -1,0 +1,199 @@
+#
+# Aura Theme > Dark Soft color scheme
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors - Dark Soft variant (desaturated/shaded)
+  accent0: '0f0f0f' # dark accent
+  accent1: '8464c6' # purple (muted)
+  accent2: '54c59f' # green/cyan (muted)
+  accent3: 'c7a06f' # orange (muted)
+  accent4: '7fc557' # lime
+  accent5: 'c55858' # red (muted)
+  accent6: 'c17ac8' # pink (muted)
+  accent7: 'bdbdbd' # foreground (muted)
+  accent8: '6d6d6d' # comments
+  accent32: '6cb2c7' # blue (muted)
+
+  # UI colors
+  accent9: 'b4b4b4' # lighter foreground (softUI variant)
+  accent10: 'adacae' # medium foreground
+  accent13: '2d2d2d' # dark gray (soft-dark variant)
+  accent15: '4d4d4d' # medium gray
+  accent22: '4d466e' # selection
+  accent23: '3b334b' # darker selection
+  accent25: '49c29a' # accent teal
+  accent28: '121016' # darker background
+
+  # Dark Soft darker variants
+  accent11: '000000' # black
+  accent12: '15141b' # background
+  accent21: '110f18' # darker background
+  accent24: '121016' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic

--- a/packages/vivid/aura-theme-dark.yml
+++ b/packages/vivid/aura-theme-dark.yml
@@ -1,0 +1,199 @@
+#
+# Aura Theme > Dark color scheme
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors
+  accent0: '0f0f0f' # dark accent
+  accent1: 'a277ff' # purple
+  accent2: '61ffca' # green/cyan
+  accent3: 'ffca85' # orange
+  accent4: '9dff65' # lime
+  accent5: 'ff6767' # red
+  accent6: 'f694ff' # pink
+  accent7: 'edecee' # foreground
+  accent8: '6d6d6d' # comments
+  accent32: '82e2ff' # blue
+
+  # UI colors
+  accent9: 'cdccce' # lighter foreground
+  accent10: 'adacae' # medium foreground
+  accent13: '2d2d2d' # dark gray
+  accent15: '4d4d4d' # medium gray
+  accent22: '4d466e' # selection
+  accent23: '3b334b' # darker selection
+  accent25: '49c29a' # accent teal
+  accent28: '121016' # darker background
+
+  # Darker variants
+  accent11: '000000' # black
+  accent12: '15141b' # background
+  accent21: '110f18' # darker background
+  accent24: '121016' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic

--- a/src/ports/vivid/index.ts
+++ b/src/ports/vivid/index.ts
@@ -1,0 +1,50 @@
+import { AuraAPI } from 'core'
+import { resolve } from 'path'
+
+export async function VividPort(Aura: AuraAPI) {
+  const { createPort, createReadme, colorSchemes, constants } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+  const { info } = constants
+
+  const portName = 'Vivid'
+  const version = '1.0.0'
+  const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-vivid-preview.png?raw=true`
+
+  // Strip # from hex colors for Vivid compatibility
+  const stripHashFromScheme = (scheme: Record<string, unknown>) =>
+    Object.entries(scheme).reduce((acc, [key, value]) => {
+      if (typeof value === 'string' && value.startsWith('#')) {
+        return { ...acc, [key]: value.replace('#', '') }
+      }
+      return { ...acc, [key]: value }
+    }, {})
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}-dark.yml`),
+    outputFileName: `${info.slug}-dark`,
+    replacements: {
+      ...stripHashFromScheme(colorSchemes.dark),
+      ...info,
+      version,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}-dark-soft.yml`),
+    outputFileName: `${info.slug}-dark-soft`,
+    replacements: {
+      ...stripHashFromScheme(colorSchemes.darkSoft),
+      ...info,
+      version,
+    },
+  })
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {
+      portName,
+      version,
+      previewURL,
+    },
+  })
+}

--- a/src/ports/vivid/templates/README.md
+++ b/src/ports/vivid/templates/README.md
@@ -44,7 +44,7 @@ Ensure you have Vivid installed on your system. You can find installation instru
 2. Fetch the `{{ slug}}-dark.yml` and `{{ slug }}-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/{{ slug }}) with the following command:
 
    ```sh
-   curl -o ~/.config/vivid/themes/{{ slug }}-dark.yml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/vivid/{{ slug }}-dark.yml
+   curl -o ~/.config/vivid/themes/{{ slug }}-dark.yml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages/vivid/{{ slug }}-dark.yml
    ```
 
    **NOTE:** You can replace `{{ slug }}-dark.yml` with `{{ slug }}-dark-soft.yml` in the command above to download the Dark Soft variant.

--- a/src/ports/vivid/templates/README.md
+++ b/src/ports/vivid/templates/README.md
@@ -4,37 +4,6 @@
 
 Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
 
-## Option 1: Use the version bundled with Vivid
-
-1. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from Vivid's themes:
-
-   ```sh
-   export LS_COLORS="$(vivid generate {{ slug }}-dark)"
-   ```
-
-   or for the Dark Soft variant:
-
-   ```sh
-   export LS_COLORS="$(vivid generate {{ slug }}-dark-soft)"
-   ```
-
-   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
-
-   ```sh
-   if ! command -v gls &> /dev/null; then
-     brew install coreutils
-     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
-   fi
-   ```
-
-2. Restart your terminal or source your RC file to apply the changes:
-
-   ```sh
-   source ~/.zshrc  # or source ~/.bashrc, etc.
-   ```
-
-## Option 2: Manually install the theme files
-
 1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
 
    ```sh
@@ -61,11 +30,26 @@ Ensure you have Vivid installed on your system. You can find installation instru
    export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/{{ slug }}-dark-soft.yml)"
    ```
 
+   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
+
+   ```sh
+   if ! command -v gls &> /dev/null; then
+     brew install coreutils
+     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
+   fi
+   ```
+
 4. Restart your terminal or source your RC file to apply the changes:
 
    ```sh
    source ~/.zshrc  # or source ~/.bashrc, etc.
    ```
+
+<br>
+
+> **A note on using Vivid's internal themes**
+>
+> Vivid comes with a set of built-in themes that you can use without needing to download any additional files. Native support within Vivid for the Aura theme may be added in the future, pending approval and an updated build by the Vivid maintainer.
 
 {{{ done }}}
 

--- a/src/ports/vivid/templates/README.md
+++ b/src/ports/vivid/templates/README.md
@@ -2,9 +2,9 @@
 
 # Installation
 
-Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
+Ensure you have **Vivid** installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
 
-1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
+1. Create a directory to store custom themes for **Vivid** (if it doesn't already exist):
 
    ```sh
    mkdir -p ~/.config/vivid/themes
@@ -18,7 +18,7 @@ Ensure you have Vivid installed on your system. You can find installation instru
 
    **NOTE:** You can replace `{{ slug }}-dark.yml` with `{{ slug }}-dark-soft.yml` in the command above to download the Dark Soft variant.
 
-3. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
+3. Add the {{ displayName }} to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
 
    ```sh
    export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/{{ slug }}-dark.yml)"
@@ -47,9 +47,9 @@ Ensure you have Vivid installed on your system. You can find installation instru
 
 <br>
 
-> **A note on using Vivid's internal themes**
+> A note on using **Vivid's** internal themes
 >
-> Vivid comes with a set of built-in themes that you can use without needing to download any additional files. Native support within Vivid for the Aura theme may be added in the future, pending approval and an updated build by the Vivid maintainer.
+> **Vivid** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Vivid** for the {{ displayName }} may be added in the future, pending PR approval and an updated build by the Vivid maintainer.
 
 {{{ done }}}
 

--- a/src/ports/vivid/templates/README.md
+++ b/src/ports/vivid/templates/README.md
@@ -41,7 +41,7 @@ Ensure you have Vivid installed on your system. You can find installation instru
    mkdir -p ~/.config/vivid/themes
    ```
 
-2. Fetch the `{{ slug}}-dark.yml` and `{{ slug }}-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/{{ slug }}) with the following command:
+2. Fetch the `{{ slug }}-dark.yml` and `{{ slug }}-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/{{ slug }}) with the following command:
 
    ```sh
    curl -o ~/.config/vivid/themes/{{ slug }}-dark.yml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages/vivid/{{ slug }}-dark.yml

--- a/src/ports/vivid/templates/README.md
+++ b/src/ports/vivid/templates/README.md
@@ -1,0 +1,96 @@
+{{{ basic-heading }}}
+
+# Installation
+
+Ensure you have Vivid installed on your system. You can find installation instructions on the [Vivid GitHub repository](https://github.com/sharkdp/vivid).
+
+## Option 1: Use the version bundled with Vivid
+
+1. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from Vivid's themes:
+
+   ```sh
+   export LS_COLORS="$(vivid generate {{ slug }}-dark)"
+   ```
+
+   or for the Dark Soft variant:
+
+   ```sh
+   export LS_COLORS="$(vivid generate {{ slug }}-dark-soft)"
+   ```
+
+   **NOTE:** On MacOS, you may need to use the GNU version of `ls` (e.g., `gls`) as the default BSD version of `ls` does not support colorization:
+
+   ```sh
+   if ! command -v gls &> /dev/null; then
+     brew install coreutils
+     echo 'alias ls="gls --color=auto"' >> ~/.zshrc
+   fi
+   ```
+
+2. Restart your terminal or source your RC file to apply the changes:
+
+   ```sh
+   source ~/.zshrc  # or source ~/.bashrc, etc.
+   ```
+
+## Option 2: Manually install the theme files
+
+1. Create a directory to store custom themes for Vivid (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/vivid/themes
+   ```
+
+2. Fetch the `{{ slug}}-dark.yml` and `{{ slug }}-dark-soft.yml` files from the [repository](https://github.com/daltonmenezes/{{ slug }}) with the following command:
+
+   ```sh
+   curl -o ~/.config/vivid/themes/{{ slug }}-dark.yml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/vivid/{{ slug }}-dark.yml
+   ```
+
+   **NOTE:** You can replace `{{ slug }}-dark.yml` with `{{ slug }}-dark-soft.yml` in the command above to download the Dark Soft variant.
+
+3. Add the Aura theme to your shell RC file (e.g., `~/.bashrc`, `~/.zshrc`, etc.) by sourcing the theme directly from your local Vivid themes:
+
+   ```sh
+   export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/{{ slug }}-dark.yml)"
+   ```
+
+   or for the Dark Soft variant:
+
+   ```sh
+   export LS_COLORS="$(vivid generate ${HOME}/.config/vivid/themes/{{ slug }}-dark-soft.yml)"
+   ```
+
+4. Restart your terminal or source your RC file to apply the changes:
+
+   ```sh
+   source ~/.zshrc  # or source ~/.bashrc, etc.
+   ```
+
+{{{ done }}}
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      {{{ author-thead }}}
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      {{{ author-tbody }}}
+    </tr>
+  </tbody>
+</table>
+
+{{{ footer }}}

--- a/src/ports/vivid/templates/aura-theme-dark-soft.yml
+++ b/src/ports/vivid/templates/aura-theme-dark-soft.yml
@@ -1,0 +1,199 @@
+#
+# {{ displayName }} > Dark Soft color scheme
+# Repository: {{{ repository }}}
+# Theme version: {{ version }}
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors - Dark Soft variant (desaturated/shaded)
+  accent0: '{{ accent0 }}' # dark accent
+  accent1: '{{ accent1 }}' # purple (muted)
+  accent2: '{{ accent2 }}' # green/cyan (muted)
+  accent3: '{{ accent3 }}' # orange (muted)
+  accent4: '{{ accent4 }}' # lime
+  accent5: '{{ accent5 }}' # red (muted)
+  accent6: '{{ accent6 }}' # pink (muted)
+  accent7: '{{ accent7 }}' # foreground (muted)
+  accent8: '{{ accent8 }}' # comments
+  accent32: '{{ accent32 }}' # blue (muted)
+
+  # UI colors
+  accent9: '{{ accent9 }}' # lighter foreground (softUI variant)
+  accent10: '{{ accent10 }}' # medium foreground
+  accent13: '{{ accent13 }}' # dark gray (soft-dark variant)
+  accent15: '{{ accent15 }}' # medium gray
+  accent22: '{{ accent22 }}' # selection
+  accent23: '{{ accent23 }}' # darker selection
+  accent25: '{{ accent25 }}' # accent teal
+  accent28: '{{ accent28 }}' # darker background
+
+  # Dark Soft darker variants
+  accent11: '{{ accent11 }}' # black
+  accent12: '{{ accent12 }}' # background
+  accent21: '{{ accent21 }}' # darker background
+  accent24: '{{ accent24 }}' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic

--- a/src/ports/vivid/templates/aura-theme-dark.yml
+++ b/src/ports/vivid/templates/aura-theme-dark.yml
@@ -1,0 +1,199 @@
+#
+# {{ displayName }} > Dark color scheme
+# Repository: {{{ repository }}}
+# Theme version: {{ version }}
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+colors:
+  # Primary colors
+  accent0: '{{ accent0 }}' # dark accent
+  accent1: '{{ accent1 }}' # purple
+  accent2: '{{ accent2 }}' # green/cyan
+  accent3: '{{ accent3 }}' # orange
+  accent4: '{{ accent4 }}' # lime
+  accent5: '{{ accent5 }}' # red
+  accent6: '{{ accent6 }}' # pink
+  accent7: '{{ accent7 }}' # foreground
+  accent8: '{{ accent8 }}' # comments
+  accent32: '{{ accent32 }}' # blue
+
+  # UI colors
+  accent9: '{{ accent9 }}' # lighter foreground
+  accent10: '{{ accent10 }}' # medium foreground
+  accent13: '{{ accent13 }}' # dark gray
+  accent15: '{{ accent15 }}' # medium gray
+  accent22: '{{ accent22 }}' # selection
+  accent23: '{{ accent23 }}' # darker selection
+  accent25: '{{ accent25 }}' # accent teal
+  accent28: '{{ accent28 }}' # darker background
+
+  # Darker variants
+  accent11: '{{ accent11 }}' # black
+  accent12: '{{ accent12 }}' # background
+  accent21: '{{ accent21 }}' # darker background
+  accent24: '{{ accent24 }}' # darkest background
+
+core:
+  normal_text:
+    foreground: accent8
+
+  regular_file:
+    foreground: accent7
+
+  reset_to_normal:
+    foreground: accent8
+
+  directory:
+    foreground: accent1
+    font-style: bold
+
+  executable_file:
+    foreground: accent2
+    font-style: bold
+
+  file_with_capability:
+    foreground: accent7
+    background: accent23
+    font-style:
+      - bold
+      - underline
+
+  setuid:
+    foreground: accent7
+    background: accent5
+
+  setgid:
+    foreground: accent11
+    background: accent3
+
+  sticky:
+    foreground: accent7
+    background: accent1
+
+  sticky_other_writable:
+    foreground: accent11
+    background: accent1
+    font-style: bold
+
+  other_writable:
+    foreground: accent1
+    background: accent23
+    font-style: bold
+
+  symlink:
+    foreground: accent32
+    font-style: italic
+
+  broken_symlink:
+    foreground: accent11
+    background: accent5
+
+  missing_symlink_target:
+    foreground: accent5
+
+  multi_hard_link:
+    foreground: accent32
+    font-style: underline
+
+  socket:
+    foreground: accent6
+    background: accent28
+    font-style: bold
+
+  fifo:
+    foreground: accent3
+    background: accent28
+    font-style: bold
+
+  door:
+    foreground: accent2
+    background: accent28
+    font-style: bold
+
+  block_device:
+    foreground: accent5
+    background: accent21
+    font-style: bold
+
+  character_device:
+    foreground: accent3
+    background: accent21
+    font-style: bold
+
+executable:
+  foreground: accent2
+  font-style: bold
+
+archives:
+  foreground: accent5
+  font-style: bold
+
+  images:
+    foreground: accent3
+    font-style: bold
+
+media:
+  audio:
+    foreground: accent32
+    font-style: bold
+
+  image:
+    foreground: accent6
+    font-style: bold
+
+  video:
+    foreground: accent5
+    font-style: bold
+
+  fonts:
+    foreground: accent3
+    font-style: bold
+
+  3d:
+    foreground: accent6
+    font-style: bold
+
+office:
+  foreground: accent4
+  font-style: bold
+
+text:
+  foreground: accent7
+
+  configuration:
+    foreground: accent3
+
+    dockerfile:
+      foreground: accent32
+
+  licenses:
+    foreground: accent8
+    font-style: italic
+
+  special:
+    foreground: accent32
+    font-style: bold
+
+  todo:
+    foreground: accent3
+    font-style: bold
+
+markup:
+  foreground: accent3
+
+programming:
+  foreground: accent2
+
+  source:
+    foreground: accent2
+
+  tooling:
+    foreground: accent32
+
+    continuous-integration:
+      foreground: accent25
+
+unimportant:
+  foreground: accent8
+  font-style: italic


### PR DESCRIPTION
#### Description

This PR: Adds support for vivid, an LS colorizer written in Rust.

#### Assets

<img width="1378" height="863" alt="aura-vivid-preview" src="https://github.com/user-attachments/assets/4ce0f1c1-4bff-40a9-92db-e7386c2f48e5" />

<!--
If this PR is about a new port, you must provide:
  1. An image to the icon of the app that this port is related to
  2. A screenshot with a good zoom in fullscreen showing this port in action

If this PR is not about a new port: remove this "Assets" section 
-->

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually
- [ ] I've added this port at the end of the related category list in the [main README](https://github.com/daltonmenezes/aura-theme/blob/main/README.md)
- [ ] I've attached an image to the icon of the app that this port is related to
- [x] I've attached a screenshot with a good zoom in fullscreen showing this port in action

#### PR Submitter Notes

1. Regarding #244 - I have not added this to the Aura Theme README as it deserves it's own section
2. The **vivid** CLI app does not provide an icon/logo
3. I also haven't included the preview in the main README as these are stored in your **'assets'** repo
