### PR TITLE
feat(port): add lsd port

### DIFF
--- a/packages/lsd/README.md
+++ b/packages/lsd/README.md
@@ -1,0 +1,113 @@
+<p align="center">
+  <img src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/new-heading.png?raw=true" alt="Aura Theme" width="70%" />
+</p>
+
+<p align="center">
+✨ A beautiful dark theme for Lsd and other apps
+  <br><br>
+
+  <!-- Patreon -->
+  <a href="https://www.patreon.com/daltonmenezes">
+    <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+
+  <!-- version -->
+  <a href="#">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+</p>
+
+<p align="center">
+  <img alt="preview" src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/aura-lsd-preview.png?raw=true" />
+</p>
+
+
+## Installation
+
+Ensure you already have **LSD** installed on your system. You can find installation instructions on the [GitHub repository](https://github.com/lsd-rs/lsd) for **LSD**.
+
+1. Create a directory to store the config and color scheme for **LSD** (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/lsd
+   ```
+
+2. Fetch either the `dark-colors.yaml` or `dark-soft-colors.yaml` file from the [repository](https://github.com/daltonmenezes/aura-theme) with the following command:
+
+   ```sh
+   curl -o ~/.config/lsd/colors.yaml https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/lsd/dark-colors.yaml
+   ```
+
+   **NOTE:** You can replace `dark-colors.yaml` with `dark-soft-colors.yaml` in the command above to download the Dark Soft variant.
+
+3. Also fetch the the example `config.yaml` configuration file if you don't have one already:
+
+   ```sh
+    curl -o ~/.config/lsd/config.yaml https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/lsd/config.yaml
+   ```
+
+4. Update the `config.yaml` file with your preferred settings, making sure to keep/set the value of the **`theme`** option to `custom`;
+
+   ```yaml
+   color:
+     when: always
+     theme: custom
+   ```
+
+## Usage Tips
+
+- The **LSD** repository recommends using some useful aliases for better experience. You should consider adding the following aliases to your shell configuration file (e.g., `~/.bashrc`, `~/.zshrc`, etc.):
+
+  ```sh
+  alias ls='lsd'
+  alias l='ls -l'
+  alias la='ls -a'
+  alias lla='ls -la'
+  alias lt='ls --tree
+  ```
+
+- To colorize the file names to match Aura Theme, **LSD** supports custom color schemes via the `LS_COLORS` environment variable. You can set this up with the Aura Theme color scheme for **Vivid** that is also packaged in this repository.
+
+  Check out the [Aura Theme for Vivid README](https://github.com/daltonmenezes/aura-theme/blob/main/packages/vivid/README.md) for more details.
+
+<br/>
+
+> A note on using **Vivid's** internal themes
+>
+> **Vivid** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Vivid** for the Aura Theme may be added in the future, pending PR approval and an updated build by the maintainer.
+
+<br/>
+Done! ✨ 🎉
+<br/>
+<br/>
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      <td valign="bottom"><p align="center">
+  <a href="https://github.com/daltonmenezes">
+    <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
+  </a>
+</p></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+    </tr>
+  </tbody>
+</table>
+
+# License
+[MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)

--- a/packages/lsd/config.yaml
+++ b/packages/lsd/config.yaml
@@ -1,0 +1,150 @@
+# == Classic ==
+# This is a shorthand to override some of the options to be backwards compatible
+# with `ls`. It affects the "color"->"when", "sorting"->"dir-grouping", "date"
+# and "icons"->"when" options.
+# Possible values: false, true
+classic: false
+
+# == Blocks ==
+# This specifies the columns and their order when using the long and the tree
+# layout.
+# Possible values: permission, user, group, context, size, date, name, inode, links, git
+blocks:
+  - permission
+  - user
+  - group
+  - size
+  - date
+  - name
+
+# == Color ==
+# This has various color options. (Will be expanded in the future.)
+color:
+  # When to colorize the output.
+  # When "classic" is set, this is set to "never".
+  # Possible values: never, auto, always
+  when: always
+  # How to colorize the output.
+  # When "classic" is set, this is set to "no-color".
+  # Possible values: default, custom
+  # When "custom" is set, lsd will look in the config directory for `colors.yaml`.
+  theme: custom
+
+# == Date ==
+# This specifies the date format for the date column. The freeform format
+# accepts a strftime like string.
+# When "classic" is set, this is set to "date".
+# Possible values: date, locale, relative, '+<date_format>'
+# `date_format` will be a `strftime` formatted value. e.g. `date: '+%d %b %y %X'` will give you a date like this: 17 Jun 21 20:14:55
+date: date
+
+# == Dereference ==
+# Whether to dereference symbolic links.
+# Possible values: false, true
+dereference: false
+
+# == Display ==
+# What items to display. Do not specify this for the default behavior.
+# Possible values: all, almost-all, directory-only
+# display: all
+
+# == Icons ==
+icons:
+  # When to use icons.
+  # When "classic" is set, this is set to "never".
+  # Possible values: always, auto, never
+  when: always
+  # Which icon theme to use.
+  # Possible values: fancy, unicode
+  theme: fancy
+  # Separator between icon and the name
+  # Default to 1 space
+  separator: ' '
+
+# == Ignore Globs ==
+# A list of globs to ignore when listing.
+# ignore-globs:
+#   - .git
+#   - node_modules
+#   - __pycache__
+
+# == Indicators ==
+# Whether to add indicator characters to certain listed files.
+# Possible values: false, true
+indicators: false
+
+# == Layout ==
+# Which layout to use. "oneline" might be a bit confusing here and should be
+# called "one-per-line". It might be changed in the future.
+# Possible values: grid, tree, oneline
+layout: grid
+
+# == Recursion ==
+recursion:
+  # Whether to enable recursion.
+  # Possible values: false, true
+  enabled: false
+  # How deep the recursion should go. This has to be a positive integer. Leave
+  # it unspecified for (virtually) infinite.
+  # depth: 3
+
+# == Size ==
+# Specifies the format of the size column.
+# Possible values: default, short, bytes
+size: default
+
+# == Permission ==
+# Specify the format of the permission column
+# Possible value: rwx, octal, attributes (windows only), disable
+permission: rwx
+
+# == Sorting ==
+sorting:
+  # Specify what to sort by.
+  # Possible values: extension, name, time, size, version
+  column: name
+  # Whether to reverse the sorting.
+  # Possible values: false, true
+  reverse: false
+  # Whether to group directories together and where.
+  # When "classic" is set, this is set to "none".
+  # Possible values: first, last, none
+  dir-grouping: first
+
+# == No Symlink ==
+# Whether to omit showing symlink targets
+# Possible values: false, true
+no-symlink: false
+
+# == Total size ==
+# Whether to display the total size of directories.
+# Possible values: false, true
+total-size: false
+
+# == Hyperlink ==
+# Attach hyperlink to filenames
+# Possible values: always, auto, never
+hyperlink: never
+
+# == Symlink arrow ==
+# Specifies how the symlink arrow display, chars in both ascii and utf8
+symlink-arrow: ⇒
+
+# == Header ==
+# Whether to display block headers.
+# Possible values: false, true
+header: false
+
+# == Literal ==
+# Whether to show quotes on filenames.
+# Possible values: false, true
+literal: false
+
+# == Truncate owner ==
+# How to truncate the username and group names for a file if they exceed a certain
+# number of characters.
+truncate-owner:
+  # Number of characters to keep. By default, no truncation is done (empty value).
+  after:
+  # String to be appended to a name if truncated.
+  marker: ''

--- a/packages/lsd/dark-colors.yaml
+++ b/packages/lsd/dark-colors.yaml
@@ -1,0 +1,46 @@
+#
+# Aura Theme color scheme for lsd
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+user: '#a277ff' # purple
+group: '#82e2ff' # blue
+permission:
+  read: '#61ffca' # green
+  write: '#ffca85' # orange
+  execute: '#ff6767' # red
+  exec: '#ff6767' # red
+  exec-sticky: '#a277ff' # purple
+  no-access: '#6d6d6d' # gray
+  octal: '#61ffca' # green
+  acl: '#49c29a' # teal
+  context: '#82e2ff' # blue
+date:
+  hour-old: '#61ffca' # green
+  day-old: '#49c29a' # teal
+  older: '#3ea7847f' # dark teal
+size:
+  none: '#6d6d6d' # gray
+  small: '#61ffca' # green
+  medium: '#ffca85' # orange
+  large: '#ff6767' # red
+inode:
+  valid: '#edecee' # white
+  invalid: '#6d6d6d' # gray
+links:
+  valid: '#f694ff' # pink
+  invalid: '#ff6767' # red
+tree-edge: '#a277ff' # purple
+git-status:
+  default: '#edecee' # white
+  unmodified: '#6d6d6d' # gray
+  ignored: '#6d6d6d' # gray
+  new-in-index: '#61ffca' # green
+  new-in-workdir: '#9dff65' # bright green
+  typechange: '#ffca85' # orange
+  deleted: '#ff6767' # red
+  renamed: '#82e2ff' # blue
+  modified: '#ffca85' # orange
+  conflicted: '#ff6767' # red

--- a/packages/lsd/dark-colors.yaml
+++ b/packages/lsd/dark-colors.yaml
@@ -19,7 +19,7 @@ permission:
 date:
   hour-old: '#61ffca' # green
   day-old: '#49c29a' # teal
-  older: '#3ea7847f' # dark teal
+  older: '#3ea784' # dark teal
 size:
   none: '#6d6d6d' # gray
   small: '#61ffca' # green

--- a/packages/lsd/dark-colors.yaml
+++ b/packages/lsd/dark-colors.yaml
@@ -10,7 +10,6 @@ group: '#82e2ff' # blue
 permission:
   read: '#61ffca' # green
   write: '#ffca85' # orange
-  execute: '#ff6767' # red
   exec: '#ff6767' # red
   exec-sticky: '#a277ff' # purple
   no-access: '#6d6d6d' # gray

--- a/packages/lsd/dark-soft-colors.yaml
+++ b/packages/lsd/dark-soft-colors.yaml
@@ -1,0 +1,46 @@
+#
+# Aura Theme color scheme for lsd
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+user: '#8464c6' # purple
+group: '#6cb2c7' # blue
+permission:
+  read: '#54c59f' # green
+  write: '#c7a06f' # orange
+  execute: '#c55858' # red
+  exec: '#c55858' # red
+  exec-sticky: '#8464c6' # purple
+  no-access: '#6d6d6d' # gray
+  octal: '#54c59f' # green
+  acl: '#49c29a' # teal
+  context: '#6cb2c7' # blue
+date:
+  hour-old: '#54c59f' # green
+  day-old: '#49c29a' # teal
+  older: '#3ea7847f' # dark teal
+size:
+  none: '#6d6d6d' # gray
+  small: '#54c59f' # green
+  medium: '#c7a06f' # orange
+  large: '#c55858' # red
+inode:
+  valid: '#bdbdbd' # white
+  invalid: '#6d6d6d' # gray
+links:
+  valid: '#c17ac8' # pink
+  invalid: '#c55858' # red
+tree-edge: '#8464c6' # purple
+git-status:
+  default: '#bdbdbd' # white
+  unmodified: '#6d6d6d' # gray
+  ignored: '#6d6d6d' # gray
+  new-in-index: '#54c59f' # green
+  new-in-workdir: '#7fc557' # bright green
+  typechange: '#c7a06f' # orange
+  deleted: '#c55858' # red
+  renamed: '#6cb2c7' # blue
+  modified: '#c7a06f' # orange
+  conflicted: '#c55858' # red

--- a/packages/lsd/dark-soft-colors.yaml
+++ b/packages/lsd/dark-soft-colors.yaml
@@ -19,7 +19,7 @@ permission:
 date:
   hour-old: '#54c59f' # green
   day-old: '#49c29a' # teal
-  older: '#3ea7847f' # dark teal
+  older: '#3ea784' # dark teal
 size:
   none: '#6d6d6d' # gray
   small: '#54c59f' # green

--- a/packages/lsd/dark-soft-colors.yaml
+++ b/packages/lsd/dark-soft-colors.yaml
@@ -10,7 +10,6 @@ group: '#6cb2c7' # blue
 permission:
   read: '#54c59f' # green
   write: '#c7a06f' # orange
-  execute: '#c55858' # red
   exec: '#c55858' # red
   exec-sticky: '#8464c6' # purple
   no-access: '#6d6d6d' # gray

--- a/src/ports/lsd/extra/config.yaml
+++ b/src/ports/lsd/extra/config.yaml
@@ -1,0 +1,150 @@
+# == Classic ==
+# This is a shorthand to override some of the options to be backwards compatible
+# with `ls`. It affects the "color"->"when", "sorting"->"dir-grouping", "date"
+# and "icons"->"when" options.
+# Possible values: false, true
+classic: false
+
+# == Blocks ==
+# This specifies the columns and their order when using the long and the tree
+# layout.
+# Possible values: permission, user, group, context, size, date, name, inode, links, git
+blocks:
+  - permission
+  - user
+  - group
+  - size
+  - date
+  - name
+
+# == Color ==
+# This has various color options. (Will be expanded in the future.)
+color:
+  # When to colorize the output.
+  # When "classic" is set, this is set to "never".
+  # Possible values: never, auto, always
+  when: always
+  # How to colorize the output.
+  # When "classic" is set, this is set to "no-color".
+  # Possible values: default, custom
+  # When "custom" is set, lsd will look in the config directory for `colors.yaml`.
+  theme: custom
+
+# == Date ==
+# This specifies the date format for the date column. The freeform format
+# accepts a strftime like string.
+# When "classic" is set, this is set to "date".
+# Possible values: date, locale, relative, '+<date_format>'
+# `date_format` will be a `strftime` formatted value. e.g. `date: '+%d %b %y %X'` will give you a date like this: 17 Jun 21 20:14:55
+date: date
+
+# == Dereference ==
+# Whether to dereference symbolic links.
+# Possible values: false, true
+dereference: false
+
+# == Display ==
+# What items to display. Do not specify this for the default behavior.
+# Possible values: all, almost-all, directory-only
+# display: all
+
+# == Icons ==
+icons:
+  # When to use icons.
+  # When "classic" is set, this is set to "never".
+  # Possible values: always, auto, never
+  when: always
+  # Which icon theme to use.
+  # Possible values: fancy, unicode
+  theme: fancy
+  # Separator between icon and the name
+  # Default to 1 space
+  separator: ' '
+
+# == Ignore Globs ==
+# A list of globs to ignore when listing.
+# ignore-globs:
+#   - .git
+#   - node_modules
+#   - __pycache__
+
+# == Indicators ==
+# Whether to add indicator characters to certain listed files.
+# Possible values: false, true
+indicators: false
+
+# == Layout ==
+# Which layout to use. "oneline" might be a bit confusing here and should be
+# called "one-per-line". It might be changed in the future.
+# Possible values: grid, tree, oneline
+layout: grid
+
+# == Recursion ==
+recursion:
+  # Whether to enable recursion.
+  # Possible values: false, true
+  enabled: false
+  # How deep the recursion should go. This has to be a positive integer. Leave
+  # it unspecified for (virtually) infinite.
+  # depth: 3
+
+# == Size ==
+# Specifies the format of the size column.
+# Possible values: default, short, bytes
+size: default
+
+# == Permission ==
+# Specify the format of the permission column
+# Possible value: rwx, octal, attributes (windows only), disable
+permission: rwx
+
+# == Sorting ==
+sorting:
+  # Specify what to sort by.
+  # Possible values: extension, name, time, size, version
+  column: name
+  # Whether to reverse the sorting.
+  # Possible values: false, true
+  reverse: false
+  # Whether to group directories together and where.
+  # When "classic" is set, this is set to "none".
+  # Possible values: first, last, none
+  dir-grouping: first
+
+# == No Symlink ==
+# Whether to omit showing symlink targets
+# Possible values: false, true
+no-symlink: false
+
+# == Total size ==
+# Whether to display the total size of directories.
+# Possible values: false, true
+total-size: false
+
+# == Hyperlink ==
+# Attach hyperlink to filenames
+# Possible values: always, auto, never
+hyperlink: never
+
+# == Symlink arrow ==
+# Specifies how the symlink arrow display, chars in both ascii and utf8
+symlink-arrow: ⇒
+
+# == Header ==
+# Whether to display block headers.
+# Possible values: false, true
+header: false
+
+# == Literal ==
+# Whether to show quotes on filenames.
+# Possible values: false, true
+literal: false
+
+# == Truncate owner ==
+# How to truncate the username and group names for a file if they exceed a certain
+# number of characters.
+truncate-owner:
+  # Number of characters to keep. By default, no truncation is done (empty value).
+  after:
+  # String to be appended to a name if truncated.
+  marker: ''

--- a/src/ports/lsd/index.ts
+++ b/src/ports/lsd/index.ts
@@ -1,0 +1,49 @@
+import { AuraAPI } from 'core'
+import { resolve } from 'path'
+
+export async function LsdPort(Aura: AuraAPI) {
+  const {
+    createPort,
+    createReadme,
+    colorSchemes,
+    constants,
+    copyExtraFiles,
+  } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+  const { info } = constants
+
+  const portName = 'Lsd'
+  const version = '1.0.0'
+  const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-lsd-preview.png?raw=true`
+
+  await createPort({
+    template: resolve(templateFolder, `colors.yaml`),
+    outputFileName: `dark-colors`,
+    replacements: {
+      ...colorSchemes.dark,
+      ...info,
+      version,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `colors.yaml`),
+    outputFileName: `dark-soft-colors`,
+    replacements: {
+      ...colorSchemes.darkSoft,
+      ...info,
+      version,
+    },
+  })
+
+  await copyExtraFiles(__dirname)
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {
+      portName,
+      version,
+      previewURL,
+    },
+  })
+}

--- a/src/ports/lsd/index.ts
+++ b/src/ports/lsd/index.ts
@@ -16,11 +16,28 @@ export async function LsdPort(Aura: AuraAPI) {
   const version = '1.0.0'
   const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-lsd-preview.png?raw=true`
 
+  // Helper function to remove alpha channel from chosen theme colors as lsd does not support them
+  const stripAlpha = (color: string): string => {
+    if (color.length === 9 && color.startsWith('#')) {
+      return color.substring(0, 7)
+    }
+    return color
+  }
+
+  // Strip alpha channels from all accent colors
+  const stripAlphaFromScheme = (scheme: Record<string, string>) => {
+    const stripped: Record<string, string> = {}
+    for (const [key, value] of Object.entries(scheme)) {
+      stripped[key] = typeof value === 'string' ? stripAlpha(value) : value
+    }
+    return stripped
+  }
+
   await createPort({
     template: resolve(templateFolder, `colors.yaml`),
     outputFileName: `dark-colors`,
     replacements: {
-      ...colorSchemes.dark,
+      ...stripAlphaFromScheme(colorSchemes.dark),
       ...info,
       version,
     },
@@ -30,7 +47,7 @@ export async function LsdPort(Aura: AuraAPI) {
     template: resolve(templateFolder, `colors.yaml`),
     outputFileName: `dark-soft-colors`,
     replacements: {
-      ...colorSchemes.darkSoft,
+      ...stripAlphaFromScheme(colorSchemes.darkSoft),
       ...info,
       version,
     },

--- a/src/ports/lsd/templates/README.md
+++ b/src/ports/lsd/templates/README.md
@@ -1,0 +1,83 @@
+{{{ basic-heading }}}
+
+## Installation
+
+Ensure you already have **LSD** installed on your system. You can find installation instructions on the [GitHub repository](https://github.com/lsd-rs/lsd) for **LSD**.
+
+1. Create a directory to store the config and color scheme for **LSD** (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/lsd
+   ```
+
+2. Fetch either the `dark-colors.yaml` or `dark-soft-colors.yaml` file from the [repository](https://github.com/daltonmenezes/{{ slug }}) with the following command:
+
+   ```sh
+   curl -o ~/.config/lsd/colors.yaml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages/lsd/dark-colors.yaml
+   ```
+
+   **NOTE:** You can replace `dark-colors.yaml` with `dark-soft-colors.yaml` in the command above to download the Dark Soft variant.
+
+3. Also fetch the the example `config.yaml` configuration file if you don't have one already:
+
+   ```sh
+    curl -o ~/.config/lsd/config.yaml https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages/lsd/config.yaml
+   ```
+
+4. Update the `config.yaml` file with your preferred settings, making sure to keep/set the value of the **`theme`** option to `custom`;
+
+   ```yaml
+   color:
+     when: always
+     theme: custom
+   ```
+
+## Usage Tips
+
+- The **LSD** repository recommends using some useful aliases for better experience. You should consider adding the following aliases to your shell configuration file (e.g., `~/.bashrc`, `~/.zshrc`, etc.):
+
+  ```sh
+  alias ls='lsd'
+  alias l='ls -l'
+  alias la='ls -a'
+  alias lla='ls -la'
+  alias lt='ls --tree
+  ```
+
+- To colorize the file names to match {{ displayName }}, **LSD** supports custom color schemes via the `LS_COLORS` environment variable. You can set this up with the {{ displayName }} color scheme for **Vivid** that is also packaged in this repository.
+
+  Check out the [{{ displayName}} for Vivid README](https://github.com/daltonmenezes/{{ slug }}/blob/main/packages/vivid/README.md) for more details.
+
+<br/>
+
+> A note on using **Vivid's** internal themes
+>
+> **Vivid** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Vivid** for the {{ displayName }} may be added in the future, pending PR approval and an updated build by the maintainer.
+
+{{{ done }}}
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      {{{ author-thead }}}
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      {{{ author-tbody }}}
+    </tr>
+  </tbody>
+</table>
+
+{{{ footer }}}

--- a/src/ports/lsd/templates/colors.yaml
+++ b/src/ports/lsd/templates/colors.yaml
@@ -1,0 +1,46 @@
+#
+# {{ displayName }} color scheme for lsd
+# Repository: {{{ repository }}}
+# Theme version: {{ version }}
+#
+# Color names reference the accent naming convention from aura-theme/src/core/colors/schemes/
+
+user: '{{ accent1 }}' # purple
+group: '{{ accent32 }}' # blue
+permission:
+  read: '{{ accent2 }}' # green
+  write: '{{ accent3 }}' # orange
+  execute: '{{ accent5 }}' # red
+  exec: '{{ accent5 }}' # red
+  exec-sticky: '{{ accent1 }}' # purple
+  no-access: '{{ accent8 }}' # gray
+  octal: '{{ accent2 }}' # green
+  acl: '{{ accent25 }}' # teal
+  context: '{{ accent32 }}' # blue
+date:
+  hour-old: '{{ accent2 }}' # green
+  day-old: '{{ accent25 }}' # teal
+  older: '{{ accent19 }}' # dark teal
+size:
+  none: '{{ accent8 }}' # gray
+  small: '{{ accent2 }}' # green
+  medium: '{{ accent3 }}' # orange
+  large: '{{ accent5 }}' # red
+inode:
+  valid: '{{ accent7 }}' # white
+  invalid: '{{ accent8 }}' # gray
+links:
+  valid: '{{ accent6 }}' # pink
+  invalid: '{{ accent5 }}' # red
+tree-edge: '{{ accent1 }}' # purple
+git-status:
+  default: '{{ accent7 }}' # white
+  unmodified: '{{ accent8 }}' # gray
+  ignored: '{{ accent8 }}' # gray
+  new-in-index: '{{ accent2 }}' # green
+  new-in-workdir: '{{ accent4 }}' # bright green
+  typechange: '{{ accent3 }}' # orange
+  deleted: '{{ accent5 }}' # red
+  renamed: '{{ accent32 }}' # blue
+  modified: '{{ accent3 }}' # orange
+  conflicted: '{{ accent5 }}' # red

--- a/src/ports/lsd/templates/colors.yaml
+++ b/src/ports/lsd/templates/colors.yaml
@@ -10,7 +10,6 @@ group: '{{ accent32 }}' # blue
 permission:
   read: '{{ accent2 }}' # green
   write: '{{ accent3 }}' # orange
-  execute: '{{ accent5 }}' # red
   exec: '{{ accent5 }}' # red
   exec-sticky: '{{ accent1 }}' # purple
   no-access: '{{ accent8 }}' # gray

--- a/src/ports/superfile/index.ts
+++ b/src/ports/superfile/index.ts
@@ -1,0 +1,27 @@
+import { AuraAPI } from 'core'
+import { resolve } from 'path'
+
+export async function SuperfilePort(Aura: AuraAPI) {
+  const { createPort, createReadme, colorSchemes, constants } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+  const { info } = constants
+
+  const portName = 'Superfile'
+  const version = '1.0.0'
+
+  // await createPort({
+  //   template: resolve(templateFolder, `${info.slug}.yml`),
+  //   replacements: {
+  //     ...colorSchemes.dark,
+  //     ...info,
+  //   },
+  // })
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {
+      portName,
+      version,
+    },
+  })
+}


### PR DESCRIPTION
#### Description

This PR: Adds support for LSD (LSDeluxe), an `ls` replacement written in Rust.

#### Assets

<img width="1386" height="871" alt="aura-lsd-preview" src="https://github.com/user-attachments/assets/5ebef7bb-b79e-4fad-a303-47184445519d" />

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually
- [ ] I've added this port at the end of the related category list in the [main README](https://github.com/daltonmenezes/aura-theme/blob/main/README.md)
- [ ] I've attached an image to the icon of the app that this port is related to
- [x] I've attached a screenshot with a good zoom in fullscreen showing this port in action

#### PR Submitter Notes

1. Regarding #244 - I have not added this to the Aura Theme README as it deserves it's own section
2. The vivid CLI app does not provide an icon/logo
3. I also haven't included the preview in the main README as these are stored in your '**assets**' repo
