### PR TITLE
feat(port): add zellij port

### DIFF
--- a/packages/zellij/README.md
+++ b/packages/zellij/README.md
@@ -1,0 +1,99 @@
+<p align="center">
+  <img src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/new-heading.png?raw=true" alt="Aura Theme" width="70%" />
+</p>
+
+<p align="center">
+✨ A beautiful dark theme for Zellij and other apps
+  <br><br>
+
+  <!-- Patreon -->
+  <a href="https://www.patreon.com/daltonmenezes">
+    <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+
+  <!-- version -->
+  <a href="#">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+</p>
+
+<p align="center">
+  <img alt="preview" src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/aura-zellij-preview.png?raw=true" />
+</p>
+
+
+## Installation
+
+Ensure you already have **Zellij** installed on your system. You can find installation instructions on the [official website](https://zellij.dev/documentation/installation.html).
+
+1. Create a directory to store custom themes for **Zellij** (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/zellij/themes
+   ```
+
+2. Fetch the `aura-theme-dark.kdl` and `aura-theme-dark-soft.kdl` files from the [repository](https://github.com/daltonmenezes/aura-theme) with the following command:
+
+   ```sh
+   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages-zellij/aura-theme-dark.kdl
+   ```
+
+   **NOTE:** You can replace `aura-theme-dark.kdl` with `aura-theme-dark-soft.kdl` in the command above to download the Dark Soft variant instead.
+
+3. Update your Zellij configuratiion file (usually located at `~/.config/zellij/config.kdl`) to set the theme. Add or modify the following line:
+
+   Replace:
+
+   ```kdl
+   // theme "default"
+   ```
+
+   With:
+
+   ```kdl
+   theme "aura-theme-dark" // or "aura-theme-dark-soft" for the soft variant
+   ```
+
+4. Restart **Zellij** to apply the new theme.
+
+<br/>
+
+> A note on using **Zellij's** internal themes
+>
+> **Zellij** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Zellij** for the Aura Theme may be added in the future, pending PR approval and an updated build by the Zellij maintainer.
+
+<br/>
+Done! ✨ 🎉
+<br/>
+<br/>
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      <td valign="bottom"><p align="center">
+  <a href="https://github.com/daltonmenezes">
+    <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
+  </a>
+</p></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+    </tr>
+  </tbody>
+</table>
+
+# License
+[MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)

--- a/packages/zellij/README.md
+++ b/packages/zellij/README.md
@@ -35,7 +35,7 @@ Ensure you already have **Zellij** installed on your system. You can find instal
 2. Fetch the `aura-theme-dark.kdl` and `aura-theme-dark-soft.kdl` files from the [repository](https://github.com/daltonmenezes/aura-theme) with the following command:
 
    ```sh
-   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages-zellij/aura-theme-dark.kdl
+   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/aura-theme/main/packages/zellij/aura-theme-dark.kdl
    ```
 
    **NOTE:** You can replace `aura-theme-dark.kdl` with `aura-theme-dark-soft.kdl` in the command above to download the Dark Soft variant instead.

--- a/packages/zellij/aura-theme-dark-soft.kdl
+++ b/packages/zellij/aura-theme-dark-soft.kdl
@@ -1,0 +1,126 @@
+//
+// Aura Theme color scheme for Zellij
+// Repository: https://github.com/daltonmenezes/aura-theme
+// Theme version: 1.0.0
+//
+
+themes {
+    aura-theme-dark-soft {
+        text_unselected {
+            base 189 189 189
+            background 21 20 27
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        text_selected {
+            base 189 189 189
+            background 41 38 60
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        ribbon_selected {
+            base 21 20 27
+            background 84 197 159
+            emphasis_0 132 100 198
+            emphasis_1 193 122 200
+            emphasis_2 197 88 88
+            emphasis_3 109 109 109
+        }
+        ribbon_unselected {
+            base 21 20 27
+            background 189 189 189
+            emphasis_0 132 100 198
+            emphasis_1 193 122 200
+            emphasis_2 197 88 88
+            emphasis_3 109 109 109
+        }
+        table_title {
+            base 84 197 159
+            background 0
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        table_cell_selected {
+            base 189 189 189
+            background 41 38 60
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        table_cell_unselected {
+            base 189 189 189
+            background 21 20 27
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        list_selected {
+            base 189 189 189
+            background 41 38 60
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        list_unselected {
+            base 189 189 189
+            background 21 20 27
+            emphasis_0 132 100 198
+            emphasis_1 84 197 159
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        frame_selected {
+            base 84 197 159
+            background 0
+            emphasis_0 0
+            emphasis_1 193 122 200
+            emphasis_2 108 178 199
+            emphasis_3 199 160 111
+        }
+        frame_highlight {
+            base 199 160 111
+            background 0
+            emphasis_0 132 100 198
+            emphasis_1 197 88 88
+            emphasis_2 108 178 199
+            emphasis_3 193 122 200
+        }
+        exit_code_success {
+            base 84 197 159
+            background 0
+            emphasis_0 132 100 198
+            emphasis_1 193 122 200
+            emphasis_2 21 20 27
+            emphasis_3 108 178 199
+        }
+        exit_code_error {
+            base 197 88 88
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 199 160 111
+        }
+        multiplayer_user_colors {
+            player_1 199 160 111
+            player_2 193 122 200
+            player_3 108 178 199
+            player_4 197 88 88
+            player_5 0
+            player_6 0
+            player_7 0
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
+}

--- a/packages/zellij/aura-theme-dark.kdl
+++ b/packages/zellij/aura-theme-dark.kdl
@@ -1,0 +1,126 @@
+//
+// Aura Theme color scheme for Zellij
+// Repository: https://github.com/daltonmenezes/aura-theme
+// Theme version: 1.0.0
+//
+
+themes {
+    aura-theme-dark {
+        text_unselected {
+            base 237 236 238
+            background 21 20 27
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        text_selected {
+            base 237 236 238
+            background 41 38 60
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        ribbon_selected {
+            base 21 20 27
+            background 97 255 202
+            emphasis_0 162 119 255
+            emphasis_1 246 148 255
+            emphasis_2 255 103 103
+            emphasis_3 109 109 109
+        }
+        ribbon_unselected {
+            base 21 20 27
+            background 237 236 238
+            emphasis_0 162 119 255
+            emphasis_1 246 148 255
+            emphasis_2 255 103 103
+            emphasis_3 109 109 109
+        }
+        table_title {
+            base 97 255 202
+            background 0
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        table_cell_selected {
+            base 237 236 238
+            background 41 38 60
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        table_cell_unselected {
+            base 237 236 238
+            background 21 20 27
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        list_selected {
+            base 237 236 238
+            background 41 38 60
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        list_unselected {
+            base 237 236 238
+            background 21 20 27
+            emphasis_0 162 119 255
+            emphasis_1 97 255 202
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        frame_selected {
+            base 97 255 202
+            background 0
+            emphasis_0 0
+            emphasis_1 246 148 255
+            emphasis_2 130 226 255
+            emphasis_3 255 202 133
+        }
+        frame_highlight {
+            base 255 202 133
+            background 0
+            emphasis_0 162 119 255
+            emphasis_1 255 103 103
+            emphasis_2 130 226 255
+            emphasis_3 246 148 255
+        }
+        exit_code_success {
+            base 97 255 202
+            background 0
+            emphasis_0 162 119 255
+            emphasis_1 246 148 255
+            emphasis_2 21 20 27
+            emphasis_3 130 226 255
+        }
+        exit_code_error {
+            base 255 103 103
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 255 202 133
+        }
+        multiplayer_user_colors {
+            player_1 255 202 133
+            player_2 246 148 255
+            player_3 130 226 255
+            player_4 255 103 103
+            player_5 0
+            player_6 0
+            player_7 0
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
+}

--- a/src/ports/zellij/index.ts
+++ b/src/ports/zellij/index.ts
@@ -1,0 +1,58 @@
+import { AuraAPI } from 'core'
+import { colorHandlers } from 'core/modules'
+import { resolve } from 'path'
+
+export async function ZellijPort(Aura: AuraAPI) {
+  const { createPort, createReadme, colorSchemes, constants } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+  const { info } = constants
+
+  const portName = 'Zellij'
+  const version = '1.0.0'
+  const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-zellij-preview.png?raw=true`
+
+  // Helper function to convert RGB arrays to space-separated strings for Zellij config
+  const rgbToSpaceSeparated = (rgbScheme: Record<string, unknown>) => {
+    return Object.entries(rgbScheme).reduce((acc, [key, value]) => {
+      if (Array.isArray(value)) {
+        acc[key] = value.join(' ')
+      } else {
+        acc[key] = value
+      }
+      return acc
+    }, {} as Record<string, unknown>)
+  }
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.kdl`),
+    outputFileName: `${info.slug}-dark`,
+    replacements: {
+      ...rgbToSpaceSeparated(colorHandlers.schemeToRgb(colorSchemes.dark)),
+      ...info,
+      version,
+      slug: `${info.slug}-dark`,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.kdl`),
+    outputFileName: `${info.slug}-dark-soft`,
+    replacements: {
+      ...rgbToSpaceSeparated(
+        colorHandlers.schemeToRgb(colorSchemes.darkSoft)
+      ),
+      ...info,
+      version,
+      slug: `${info.slug}-dark-soft`,
+    },
+  })
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {
+      portName,
+      version,
+      previewURL,
+    },
+  })
+}

--- a/src/ports/zellij/templates/README.md
+++ b/src/ports/zellij/templates/README.md
@@ -13,7 +13,7 @@ Ensure you already have **Zellij** installed on your system. You can find instal
 2. Fetch the `aura-theme-dark.kdl` and `aura-theme-dark-soft.kdl` files from the [repository]({{{ repository }}}) with the following command:
 
    ```sh
-   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages-zellij/{{ slug }}-dark.kdl
+   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages/zellij/{{ slug }}-dark.kdl
    ```
 
    **NOTE:** You can replace `{{ slug }}-dark.kdl` with `{{ slug }}-dark-soft.kdl` in the command above to download the Dark Soft variant instead.

--- a/src/ports/zellij/templates/README.md
+++ b/src/ports/zellij/templates/README.md
@@ -1,0 +1,69 @@
+{{{ basic-heading }}}
+
+## Installation
+
+Ensure you already have **Zellij** installed on your system. You can find installation instructions on the [official website](https://zellij.dev/documentation/installation.html).
+
+1. Create a directory to store custom themes for **Zellij** (if it doesn't already exist):
+
+   ```sh
+   mkdir -p ~/.config/zellij/themes
+   ```
+
+2. Fetch the `aura-theme-dark.kdl` and `aura-theme-dark-soft.kdl` files from the [repository]({{{ repository }}}) with the following command:
+
+   ```sh
+   curl -o ~/.config/zellij/themes/aura-theme-dark.kdl https://raw.githubusercontent.com/daltonmenezes/{{ slug }}/main/packages-zellij/{{ slug }}-dark.kdl
+   ```
+
+   **NOTE:** You can replace `{{ slug }}-dark.kdl` with `{{ slug }}-dark-soft.kdl` in the command above to download the Dark Soft variant instead.
+
+3. Update your Zellij configuratiion file (usually located at `~/.config/zellij/config.kdl`) to set the theme. Add or modify the following line:
+
+   Replace:
+
+   ```kdl
+   // theme "default"
+   ```
+
+   With:
+
+   ```kdl
+   theme "aura-theme-dark" // or "aura-theme-dark-soft" for the soft variant
+   ```
+
+4. Restart **Zellij** to apply the new theme.
+
+<br/>
+
+> A note on using **Zellij's** internal themes
+>
+> **Zellij** comes with a set of built-in themes that you can use without needing to download any additional files. Native support within **Zellij** for the {{ displayName }} may be added in the future, pending PR approval and an updated build by the Zellij maintainer.
+
+{{{ done }}}
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      {{{ author-thead }}}
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      {{{ author-tbody }}}
+    </tr>
+  </tbody>
+</table>
+
+{{{ footer }}}

--- a/src/ports/zellij/templates/aura-theme.kdl
+++ b/src/ports/zellij/templates/aura-theme.kdl
@@ -1,0 +1,126 @@
+//
+// {{ displayName }} color scheme for Zellij
+// Repository: {{{ repository }}}
+// Theme version: {{ version }}
+//
+
+themes {
+    {{ slug }} {
+        text_unselected {
+            base {{ accent7 }}
+            background {{ accent12 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        text_selected {
+            base {{ accent7 }}
+            background {{ accent38 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        ribbon_selected {
+            base {{ accent12 }}
+            background {{ accent2 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent6 }}
+            emphasis_2 {{ accent5 }}
+            emphasis_3 {{ accent8 }}
+        }
+        ribbon_unselected {
+            base {{ accent12 }}
+            background {{ accent7 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent6 }}
+            emphasis_2 {{ accent5 }}
+            emphasis_3 {{ accent8 }}
+        }
+        table_title {
+            base {{ accent2 }}
+            background 0
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        table_cell_selected {
+            base {{ accent7 }}
+            background {{ accent38 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        table_cell_unselected {
+            base {{ accent7 }}
+            background {{ accent12 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        list_selected {
+            base {{ accent7 }}
+            background {{ accent38 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        list_unselected {
+            base {{ accent7 }}
+            background {{ accent12 }}
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent2 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        frame_selected {
+            base {{ accent2 }}
+            background 0
+            emphasis_0 0
+            emphasis_1 {{ accent6 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent3 }}
+        }
+        frame_highlight {
+            base {{ accent3 }}
+            background 0
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent5 }}
+            emphasis_2 {{ accent32 }}
+            emphasis_3 {{ accent6 }}
+        }
+        exit_code_success {
+            base {{ accent2 }}
+            background 0
+            emphasis_0 {{ accent1 }}
+            emphasis_1 {{ accent6 }}
+            emphasis_2 {{ accent12 }}
+            emphasis_3 {{ accent32 }}
+        }
+        exit_code_error {
+            base {{ accent5 }}
+            background 0
+            emphasis_0 0
+            emphasis_1 0
+            emphasis_2 0
+            emphasis_3 {{ accent3 }}
+        }
+        multiplayer_user_colors {
+            player_1 {{ accent3 }}
+            player_2 {{ accent6 }}
+            player_3 {{ accent32 }}
+            player_4 {{ accent5 }}
+            player_5 0
+            player_6 0
+            player_7 0
+            player_8 0
+            player_9 0
+            player_10 0
+        }
+    }
+}


### PR DESCRIPTION
#### Description

This PR: Adds support for Zellij, a terminal workspace, aka "multiplexer" written in Rust.

#### Assets

<img width="25%" height="2620" alt="logo" src="https://github.com/user-attachments/assets/16a98a9a-2760-461a-826e-fec26daa2243" />

<img width="1386" height="870" alt="aura-zellij-preview" src="https://github.com/user-attachments/assets/8e327e7c-6382-45c6-b58c-496918be99a5" />

<!--
If this PR is about a new port, you must provide:
  1. An image to the icon of the app that this port is related to
  2. A screenshot with a good zoom in fullscreen showing this port in action

If this PR is not about a new port: remove this "Assets" section 
-->

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually
- [ ] I've added this port at the end of the related category list in the [main README](https://github.com/daltonmenezes/aura-theme/blob/main/README.md)
- [x] I've attached an image to the icon of the app that this port is related to
- [x] I've attached a screenshot with a good zoom in fullscreen showing this port in action

#### PR Submitter Notes

1. Regarding #244 - I have not added this to the Aura Theme README as it deserves it's own section
2. I also haven't included the preview in the main README as these are stored in your **'assets'** repo
