### PR TITLE
fix(port): replace deprecated color keys in VScode port

### DIFF
--- a/packages/vscode/themes/aura-dark-color-theme.json
+++ b/packages/vscode/themes/aura-dark-color-theme.json
@@ -39,7 +39,7 @@
     "editor.background": "#15141b",
     "editor.foreground": "#edecee",
     "editorLineNumber.foreground": "#a394f033",
-    "editorIndentGuide.activeBackground": "#6d6d6d",
+    "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#a277ff",
     "editor.selectionBackground": "#3d375e7f",
     "editor.selectionHighlightBackground": "#3d375e7f",
@@ -56,7 +56,7 @@
     "editorInlayHint.foreground": "#cdccce",
     "editorLink.activeForeground": "#a277ff",
     "editorWhitespace.foreground": "#2d2d2d",
-    "editorIndentGuide.background": "#2d2d2d",
+    "editorIndentGuide.background1": "#2d2d2d",
     "editorBracketMatch.border": "#a277ff",
     "editorError.foreground": "#ff6767",
     "editorError.border": "#ffffff00",
@@ -207,10 +207,7 @@
     },
     {
       "name": "Accent5",
-      "scope": [
-        "invalid",
-        "markup.deleted"
-      ],
+      "scope": ["invalid", "markup.deleted"],
       "settings": {
         "foreground": "#ff6767"
       }
@@ -264,20 +261,14 @@
     },
     {
       "name": "Accent8",
-      "scope": [
-        "comment",
-        "string.quoted.docstring.multi.python"
-      ],
+      "scope": ["comment", "string.quoted.docstring.multi.python"],
       "settings": {
         "foreground": "#6d6d6d"
       }
     },
     {
       "name": "Accent31",
-      "scope": [
-        "entity.name.function",
-        "support.function"
-      ],
+      "scope": ["entity.name.function", "support.function"],
       "settings": {
         "foreground": "#ffca85"
       }
@@ -325,10 +316,7 @@
     },
     {
       "name": "Bold",
-      "scope": [
-        "markup.bold.markdown",
-        "storage.type.annotation.dart"
-      ],
+      "scope": ["markup.bold.markdown", "storage.type.annotation.dart"],
       "settings": {
         "fontStyle": "bold"
       }

--- a/packages/vscode/themes/aura-dark-color-theme.json
+++ b/packages/vscode/themes/aura-dark-color-theme.json
@@ -41,7 +41,7 @@
     "editorLineNumber.foreground": "#a394f033",
     "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#a277ff",
-    "editor.selectionBackground": "#3d375e7f",
+    "editor.selectionBackground": "#4d466e",
     "editor.selectionHighlightBackground": "#3d375e7f",
     "editor.inactiveSelectionBackground": "#3d375e7f",
     "editor.wordHighlightBackground": "#3d375e7f",

--- a/packages/vscode/themes/aura-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-dark-soft-text-color-theme.json
@@ -41,7 +41,7 @@
     "editorLineNumber.foreground": "#a394f033",
     "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#8464c6",
-    "editor.selectionBackground": "#3d375e7f",
+    "editor.selectionBackground": "#4d466e",
     "editor.selectionHighlightBackground": "#3d375e7f",
     "editor.inactiveSelectionBackground": "#3d375e7f",
     "editor.wordHighlightBackground": "#3d375e7f",

--- a/packages/vscode/themes/aura-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-dark-soft-text-color-theme.json
@@ -39,7 +39,7 @@
     "editor.background": "#15141b",
     "editor.foreground": "#bdbdbd",
     "editorLineNumber.foreground": "#a394f033",
-    "editorIndentGuide.activeBackground": "#6d6d6d",
+    "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#8464c6",
     "editor.selectionBackground": "#3d375e7f",
     "editor.selectionHighlightBackground": "#3d375e7f",
@@ -56,7 +56,7 @@
     "editorInlayHint.foreground": "#b4b4b4",
     "editorLink.activeForeground": "#8464c6",
     "editorWhitespace.foreground": "#2d2d2d",
-    "editorIndentGuide.background": "#2d2d2d",
+    "editorIndentGuide.background1": "#2d2d2d",
     "editorBracketMatch.border": "#8464c6",
     "editorError.foreground": "#c55858",
     "editorError.border": "#ffffff00",
@@ -207,10 +207,7 @@
     },
     {
       "name": "Accent5",
-      "scope": [
-        "invalid",
-        "markup.deleted"
-      ],
+      "scope": ["invalid", "markup.deleted"],
       "settings": {
         "foreground": "#c55858"
       }
@@ -264,20 +261,14 @@
     },
     {
       "name": "Accent8",
-      "scope": [
-        "comment",
-        "string.quoted.docstring.multi.python"
-      ],
+      "scope": ["comment", "string.quoted.docstring.multi.python"],
       "settings": {
         "foreground": "#6d6d6d"
       }
     },
     {
       "name": "Accent31",
-      "scope": [
-        "entity.name.function",
-        "support.function"
-      ],
+      "scope": ["entity.name.function", "support.function"],
       "settings": {
         "foreground": "#c7a06f"
       }
@@ -325,10 +316,7 @@
     },
     {
       "name": "Bold",
-      "scope": [
-        "markup.bold.markdown",
-        "storage.type.annotation.dart"
-      ],
+      "scope": ["markup.bold.markdown", "storage.type.annotation.dart"],
       "settings": {
         "fontStyle": "bold"
       }

--- a/packages/vscode/themes/aura-soft-dark-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-color-theme.json
@@ -39,7 +39,7 @@
     "editor.background": "#21202e",
     "editor.foreground": "#edecee",
     "editorLineNumber.foreground": "#a394f033",
-    "editorIndentGuide.activeBackground": "#6d6d6d",
+    "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#a277ff",
     "editor.selectionBackground": "#3d375e7f",
     "editor.selectionHighlightBackground": "#3d375e7f",
@@ -56,7 +56,7 @@
     "editorInlayHint.foreground": "#cdccce",
     "editorLink.activeForeground": "#a277ff",
     "editorWhitespace.foreground": "#444444",
-    "editorIndentGuide.background": "#444444",
+    "editorIndentGuide.background1": "#444444",
     "editorBracketMatch.border": "#a277ff",
     "editorError.foreground": "#ff6767",
     "editorError.border": "#ffffff00",
@@ -207,10 +207,7 @@
     },
     {
       "name": "Accent5",
-      "scope": [
-        "invalid",
-        "markup.deleted"
-      ],
+      "scope": ["invalid", "markup.deleted"],
       "settings": {
         "foreground": "#ff6767"
       }
@@ -264,20 +261,14 @@
     },
     {
       "name": "Accent8",
-      "scope": [
-        "comment",
-        "string.quoted.docstring.multi.python"
-      ],
+      "scope": ["comment", "string.quoted.docstring.multi.python"],
       "settings": {
         "foreground": "#6d6d6d"
       }
     },
     {
       "name": "Accent31",
-      "scope": [
-        "entity.name.function",
-        "support.function"
-      ],
+      "scope": ["entity.name.function", "support.function"],
       "settings": {
         "foreground": "#ffca85"
       }
@@ -325,10 +316,7 @@
     },
     {
       "name": "Bold",
-      "scope": [
-        "markup.bold.markdown",
-        "storage.type.annotation.dart"
-      ],
+      "scope": ["markup.bold.markdown", "storage.type.annotation.dart"],
       "settings": {
         "fontStyle": "bold"
       }

--- a/packages/vscode/themes/aura-soft-dark-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-color-theme.json
@@ -41,7 +41,7 @@
     "editorLineNumber.foreground": "#a394f033",
     "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#a277ff",
-    "editor.selectionBackground": "#3d375e7f",
+    "editor.selectionBackground": "#4d466e",
     "editor.selectionHighlightBackground": "#3d375e7f",
     "editor.inactiveSelectionBackground": "#3d375e7f",
     "editor.wordHighlightBackground": "#3d375e7f",

--- a/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
@@ -39,7 +39,7 @@
     "editor.background": "#21202e",
     "editor.foreground": "#bdbdbd",
     "editorLineNumber.foreground": "#a394f033",
-    "editorIndentGuide.activeBackground": "#6d6d6d",
+    "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#8464c6",
     "editor.selectionBackground": "#3d375e7f",
     "editor.selectionHighlightBackground": "#3d375e7f",
@@ -56,7 +56,7 @@
     "editorInlayHint.foreground": "#b4b4b4",
     "editorLink.activeForeground": "#8464c6",
     "editorWhitespace.foreground": "#444444",
-    "editorIndentGuide.background": "#444444",
+    "editorIndentGuide.background1": "#444444",
     "editorBracketMatch.border": "#8464c6",
     "editorError.foreground": "#c55858",
     "editorError.border": "#ffffff00",
@@ -207,10 +207,7 @@
     },
     {
       "name": "Accent5",
-      "scope": [
-        "invalid",
-        "markup.deleted"
-      ],
+      "scope": ["invalid", "markup.deleted"],
       "settings": {
         "foreground": "#c55858"
       }
@@ -264,20 +261,14 @@
     },
     {
       "name": "Accent8",
-      "scope": [
-        "comment",
-        "string.quoted.docstring.multi.python"
-      ],
+      "scope": ["comment", "string.quoted.docstring.multi.python"],
       "settings": {
         "foreground": "#6d6d6d"
       }
     },
     {
       "name": "Accent31",
-      "scope": [
-        "entity.name.function",
-        "support.function"
-      ],
+      "scope": ["entity.name.function", "support.function"],
       "settings": {
         "foreground": "#c7a06f"
       }
@@ -325,10 +316,7 @@
     },
     {
       "name": "Bold",
-      "scope": [
-        "markup.bold.markdown",
-        "storage.type.annotation.dart"
-      ],
+      "scope": ["markup.bold.markdown", "storage.type.annotation.dart"],
       "settings": {
         "fontStyle": "bold"
       }

--- a/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
+++ b/packages/vscode/themes/aura-soft-dark-soft-text-color-theme.json
@@ -41,7 +41,7 @@
     "editorLineNumber.foreground": "#a394f033",
     "editorIndentGuide.activeBackground1": "#6d6d6d",
     "editorCursor.foreground": "#8464c6",
-    "editor.selectionBackground": "#3d375e7f",
+    "editor.selectionBackground": "#4d466e",
     "editor.selectionHighlightBackground": "#3d375e7f",
     "editor.inactiveSelectionBackground": "#3d375e7f",
     "editor.wordHighlightBackground": "#3d375e7f",

--- a/src/ports/vscode/templates/theme.json
+++ b/src/ports/vscode/templates/theme.json
@@ -39,7 +39,7 @@
     "editor.background": "{{ accent12 }}",
     "editor.foreground": "{{ accent7 }}",
     "editorLineNumber.foreground": "{{ accent17 }}",
-    "editorIndentGuide.activeBackground": "{{ accent8 }}",
+    "editorIndentGuide.activeBackground1": "{{ accent8 }}",
     "editorCursor.foreground": "{{ accent1 }}",
     "editor.selectionBackground": "{{ accent20 }}",
     "editor.selectionHighlightBackground": "{{ accent20 }}",
@@ -56,7 +56,7 @@
     "editorInlayHint.foreground": "{{ accent9 }}",
     "editorLink.activeForeground": "{{ accent1 }}",
     "editorWhitespace.foreground": "{{ accent13 }}",
-    "editorIndentGuide.background": "{{ accent13 }}",
+    "editorIndentGuide.background1": "{{ accent13 }}",
     "editorBracketMatch.border": "{{ accent1 }}",
     "editorError.foreground": "{{ accent5 }}",
     "editorError.border": "{{ accent16 }}",
@@ -207,10 +207,7 @@
     },
     {
       "name": "Accent5",
-      "scope": [
-        "invalid",
-        "markup.deleted"
-      ],
+      "scope": ["invalid", "markup.deleted"],
       "settings": {
         "foreground": "{{ accent5 }}"
       }
@@ -264,20 +261,14 @@
     },
     {
       "name": "Accent8",
-      "scope": [
-        "comment",
-        "string.quoted.docstring.multi.python"
-      ],
+      "scope": ["comment", "string.quoted.docstring.multi.python"],
       "settings": {
         "foreground": "{{ accent8 }}"
       }
     },
     {
       "name": "Accent31",
-      "scope": [
-        "entity.name.function",
-        "support.function"
-      ],
+      "scope": ["entity.name.function", "support.function"],
       "settings": {
         "foreground": "{{ accent31 }}"
       }
@@ -325,10 +316,7 @@
     },
     {
       "name": "Bold",
-      "scope": [
-        "markup.bold.markdown",
-        "storage.type.annotation.dart"
-      ],
+      "scope": ["markup.bold.markdown", "storage.type.annotation.dart"],
       "settings": {
         "fontStyle": "bold"
       }

--- a/src/ports/vscode/templates/theme.json
+++ b/src/ports/vscode/templates/theme.json
@@ -41,7 +41,7 @@
     "editorLineNumber.foreground": "{{ accent17 }}",
     "editorIndentGuide.activeBackground1": "{{ accent8 }}",
     "editorCursor.foreground": "{{ accent1 }}",
-    "editor.selectionBackground": "{{ accent20 }}",
+    "editor.selectionBackground": "{{ accent22 }}",
     "editor.selectionHighlightBackground": "{{ accent20 }}",
     "editor.inactiveSelectionBackground": "{{ accent20 }}",
     "editor.wordHighlightBackground": "{{ accent20 }}",


### PR DESCRIPTION
#### Description

This PR:
- Fixes #253 by replacing the deprecated keys with the ones provided by the JSON schema for VSCode
- Fixes #188 by swapping `editor.selectionBackground` with **"accent22"** to improve contrast of text selections across the other accent colors.  

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually

#### PR Submitter Notes

- This PR also has some formatting automatically applied by Prettier
