### PR TITLE
feat(port): add chroma port

### DIFF
--- a/packages/chroma/README.md
+++ b/packages/chroma/README.md
@@ -13,7 +13,7 @@
 
   <!-- version -->
   <a href="#">
-    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.1-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
   </a>
 </p>
 

--- a/packages/chroma/README.md
+++ b/packages/chroma/README.md
@@ -1,0 +1,64 @@
+<p align="center">
+  <img src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/new-heading.png?raw=true" alt="Aura Theme" width="70%" />
+</p>
+
+<p align="center">
+✨ A beautiful dark theme for Chroma and other apps
+  <br><br>
+
+  <!-- Patreon -->
+  <a href="https://www.patreon.com/daltonmenezes">
+    <img alt="patreon url" src="https://img.shields.io/badge/support%20on-patreon-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+
+  <!-- version -->
+  <a href="#">
+    <img alt="version" src="https://img.shields.io/badge/version%20-v1.0.0-1C1E26?style=for-the-badge&labelColor=1C1E26&color=61ffca">
+  </a>
+</p>
+
+<p align="center">
+  <img alt="preview" src="https://github.com/daltonmenezes/assets/blob/master/images/aura-theme/aura-chroma-preview.png?raw=true" />
+</p>
+
+
+# Installation
+
+Chroma is a syntax highlighter used by various applications, including static site generators like [Hugo](https://gohugo.io/), the TUI based file manager [Superfile](https://superfile.dev/), the `less` pager alternative [Moor](https://github.com/walles/moor), and others.
+
+The Aura Theme color scheme can be used within these applications simply by configuring their respective theme/color scheme settings to use Aura Theme.
+
+### Downstream updates
+
+This repo provides the template and config to generate the XML color scheme files for Chroma. Requests to include any changes or new features will require a separate PR to the Chroma [project repository](https://github.com/alecthomas/chroma) with the updated package XML files.
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      <td valign="bottom"><p align="center">
+  <a href="https://github.com/daltonmenezes">
+    <img src="https://github.com/daltonmenezes.png?size=100" align="center" />
+  </a>
+</p></td>
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      <td><a href="https://github.com/daltonmenezes">Dalton Menezes</a></td>
+    </tr>
+  </tbody>
+</table>
+
+# License
+[MIT © Dalton Menezes](https://github.com/daltonmenezes/aura-theme/blob/main/LICENSE)

--- a/packages/chroma/aura-theme-dark-soft.xml
+++ b/packages/chroma/aura-theme-dark-soft.xml
@@ -101,7 +101,7 @@
   <entry type="GenericTraceback" style="#c55858"/>
 
   <!-- Punctuation -->
-  <entry type="Punctuation" style="#bdbdbd"/>
+  <entry type="Punctuation" style="#c17ac8"/>
   <entry type="Text" style="#bdbdbd"/>
   <entry type="TextWhitespace" style="#bdbdbd"/>
 </style>

--- a/packages/chroma/aura-theme-dark-soft.xml
+++ b/packages/chroma/aura-theme-dark-soft.xml
@@ -4,7 +4,7 @@
 # Theme version: 1.0.0
 -->
 
-<style name="Aura Theme Dark Soft">
+<style name="aura-theme-dark-soft">
   <!-- Base -->
   <entry type="Background" style="bg:#15141b #bdbdbd"/>
   <entry type="CodeLine" style="#bdbdbd"/>

--- a/packages/chroma/aura-theme-dark-soft.xml
+++ b/packages/chroma/aura-theme-dark-soft.xml
@@ -1,7 +1,7 @@
 <!--
 # Aura Theme Dark Soft > Color scheme for Chroma syntax highlighter
 # Repository: https://github.com/daltonmenezes/aura-theme
-# Theme version: 1.0.0
+# Theme version: 1.0.1
 -->
 
 <style name="aura-theme-dark-soft">

--- a/packages/chroma/aura-theme-dark.xml
+++ b/packages/chroma/aura-theme-dark.xml
@@ -101,7 +101,7 @@
   <entry type="GenericTraceback" style="#ff6767"/>
 
   <!-- Punctuation -->
-  <entry type="Punctuation" style="#edecee"/>
+  <entry type="Punctuation" style="#f694ff"/>
   <entry type="Text" style="#edecee"/>
   <entry type="TextWhitespace" style="#edecee"/>
 </style>

--- a/packages/chroma/aura-theme-dark.xml
+++ b/packages/chroma/aura-theme-dark.xml
@@ -1,0 +1,107 @@
+<!--
+# Aura Theme Dark > Color scheme for Chroma syntax highlighter
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+-->
+
+<style name="Aura Theme Dark">
+  <!-- Base -->
+  <entry type="Background" style="bg:#15141b #edecee"/>
+  <entry type="CodeLine" style="#edecee"/>
+  <entry type="Error" style="#ff6767"/>
+  <entry type="Other" style="#edecee"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#29263c"/>
+  <entry type="LineNumbersTable" style="#6d6d6d"/>
+  <entry type="LineNumbers" style="#6d6d6d"/>
+
+  <!-- Keywords -->
+  <entry type="Keyword" style="#a277ff"/>
+  <entry type="KeywordReserved" style="#a277ff"/>
+  <entry type="KeywordPseudo" style="#a277ff"/>
+  <entry type="KeywordConstant" style="#61ffca"/>
+  <entry type="KeywordDeclaration" style="#a277ff"/>
+  <entry type="KeywordNamespace" style="#a277ff"/>
+  <entry type="KeywordType" style="#82e2ff"/>
+
+  <!-- Names -->
+  <entry type="Name" style="#edecee"/>
+  <entry type="NameClass" style="#82e2ff"/>
+  <entry type="NameConstant" style="#61ffca"/>
+  <entry type="NameDecorator" style="#f694ff"/>
+  <entry type="NameEntity" style="#ffca85"/>
+  <entry type="NameException" style="#ff6767"/>
+  <entry type="NameFunction" style="#ffca85"/>
+  <entry type="NameFunctionMagic" style="#ffca85"/>
+  <entry type="NameLabel" style="#f694ff"/>
+  <entry type="NameNamespace" style="#edecee"/>
+  <entry type="NameProperty" style="#f694ff"/>
+  <entry type="NameTag" style="#a277ff"/>
+  <entry type="NameVariable" style="#edecee"/>
+  <entry type="NameVariableClass" style="#edecee"/>
+  <entry type="NameVariableGlobal" style="#edecee"/>
+  <entry type="NameVariableInstance" style="#edecee"/>
+  <entry type="NameVariableMagic" style="#edecee"/>
+  <entry type="NameAttribute" style="#f694ff"/>
+  <entry type="NameBuiltin" style="#82e2ff"/>
+  <entry type="NameBuiltinPseudo" style="#82e2ff"/>
+  <entry type="NameOther" style="#edecee"/>
+
+  <!-- Literals -->
+  <entry type="Literal" style="#61ffca"/>
+  <entry type="LiteralDate" style="#61ffca"/>
+  <entry type="LiteralString" style="#61ffca"/>
+  <entry type="LiteralStringChar" style="#61ffca"/>
+  <entry type="LiteralStringSingle" style="#61ffca"/>
+  <entry type="LiteralStringDouble" style="#61ffca"/>
+  <entry type="LiteralStringBacktick" style="#61ffca"/>
+  <entry type="LiteralStringOther" style="#61ffca"/>
+  <entry type="LiteralStringSymbol" style="#61ffca"/>
+  <entry type="LiteralStringInterpol" style="#61ffca"/>
+  <entry type="LiteralStringAffix" style="#a277ff"/>
+  <entry type="LiteralStringDelimiter" style="#61ffca"/>
+  <entry type="LiteralStringEscape" style="#a277ff"/>
+  <entry type="LiteralStringRegex" style="#61ffca"/>
+  <entry type="LiteralStringDoc" style="#6d6d6d"/>
+  <entry type="LiteralStringHeredoc" style="#6d6d6d"/>
+  <entry type="LiteralNumber" style="#61ffca"/>
+  <entry type="LiteralNumberBin" style="#61ffca"/>
+  <entry type="LiteralNumberHex" style="#61ffca"/>
+  <entry type="LiteralNumberInteger" style="#61ffca"/>
+  <entry type="LiteralNumberFloat" style="#61ffca"/>
+  <entry type="LiteralNumberIntegerLong" style="#61ffca"/>
+  <entry type="LiteralNumberOct" style="#61ffca"/>
+
+  <!-- Operators -->
+  <entry type="Operator" style="#a277ff"/>
+  <entry type="OperatorWord" style="#a277ff"/>
+
+  <!-- Comments (italic) -->
+  <entry type="Comment" style="italic #6d6d6d"/>
+  <entry type="CommentSingle" style="italic #6d6d6d"/>
+  <entry type="CommentMultiline" style="italic #6d6d6d"/>
+  <entry type="CommentSpecial" style="italic #6d6d6d"/>
+  <entry type="CommentHashbang" style="italic #6d6d6d"/>
+  <entry type="CommentPreproc" style="italic #6d6d6d"/>
+  <entry type="CommentPreprocFile" style="italic #6d6d6d"/>
+
+  <!-- Generic -->
+  <entry type="Generic" style="#edecee"/>
+  <entry type="GenericInserted" style="bg:#15141b #61ffca"/>
+  <entry type="GenericDeleted" style="bg:#15141b #ff6767"/>
+  <entry type="GenericEmph" style="italic #edecee"/>
+  <entry type="GenericStrong" style="bold #edecee"/>
+  <entry type="GenericUnderline" style="underline #edecee"/>
+  <entry type="GenericHeading" style="bold #a277ff"/>
+  <entry type="GenericSubheading" style="bold #a277ff"/>
+  <entry type="GenericOutput" style="#edecee"/>
+  <entry type="GenericPrompt" style="#edecee"/>
+  <entry type="GenericError" style="#ff6767"/>
+  <entry type="GenericTraceback" style="#ff6767"/>
+
+  <!-- Punctuation -->
+  <entry type="Punctuation" style="#edecee"/>
+  <entry type="Text" style="#edecee"/>
+  <entry type="TextWhitespace" style="#edecee"/>
+</style>

--- a/packages/chroma/aura-theme-dark.xml
+++ b/packages/chroma/aura-theme-dark.xml
@@ -4,7 +4,7 @@
 # Theme version: 1.0.0
 -->
 
-<style name="Aura Theme Dark">
+<style name="aura-theme-dark">
   <!-- Base -->
   <entry type="Background" style="bg:#15141b #edecee"/>
   <entry type="CodeLine" style="#edecee"/>

--- a/packages/chroma/aura-theme-dark.xml
+++ b/packages/chroma/aura-theme-dark.xml
@@ -1,7 +1,7 @@
 <!--
 # Aura Theme Dark > Color scheme for Chroma syntax highlighter
 # Repository: https://github.com/daltonmenezes/aura-theme
-# Theme version: 1.0.0
+# Theme version: 1.0.1
 -->
 
 <style name="aura-theme-dark">

--- a/packages/chroma/aura-theme-soft-dark.xml
+++ b/packages/chroma/aura-theme-soft-dark.xml
@@ -1,0 +1,107 @@
+<!--
+# Aura Theme Dark Soft > Color scheme for Chroma syntax highlighter
+# Repository: https://github.com/daltonmenezes/aura-theme
+# Theme version: 1.0.0
+-->
+
+<style name="Aura Theme Dark Soft">
+  <!-- Base -->
+  <entry type="Background" style="bg:#15141b #bdbdbd"/>
+  <entry type="CodeLine" style="#bdbdbd"/>
+  <entry type="Error" style="#c55858"/>
+  <entry type="Other" style="#bdbdbd"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:#29263c"/>
+  <entry type="LineNumbersTable" style="#6d6d6d"/>
+  <entry type="LineNumbers" style="#6d6d6d"/>
+
+  <!-- Keywords -->
+  <entry type="Keyword" style="#8464c6"/>
+  <entry type="KeywordReserved" style="#8464c6"/>
+  <entry type="KeywordPseudo" style="#8464c6"/>
+  <entry type="KeywordConstant" style="#54c59f"/>
+  <entry type="KeywordDeclaration" style="#8464c6"/>
+  <entry type="KeywordNamespace" style="#8464c6"/>
+  <entry type="KeywordType" style="#6cb2c7"/>
+
+  <!-- Names -->
+  <entry type="Name" style="#bdbdbd"/>
+  <entry type="NameClass" style="#6cb2c7"/>
+  <entry type="NameConstant" style="#54c59f"/>
+  <entry type="NameDecorator" style="#c17ac8"/>
+  <entry type="NameEntity" style="#c7a06f"/>
+  <entry type="NameException" style="#c55858"/>
+  <entry type="NameFunction" style="#c7a06f"/>
+  <entry type="NameFunctionMagic" style="#c7a06f"/>
+  <entry type="NameLabel" style="#c17ac8"/>
+  <entry type="NameNamespace" style="#bdbdbd"/>
+  <entry type="NameProperty" style="#c17ac8"/>
+  <entry type="NameTag" style="#8464c6"/>
+  <entry type="NameVariable" style="#bdbdbd"/>
+  <entry type="NameVariableClass" style="#bdbdbd"/>
+  <entry type="NameVariableGlobal" style="#bdbdbd"/>
+  <entry type="NameVariableInstance" style="#bdbdbd"/>
+  <entry type="NameVariableMagic" style="#bdbdbd"/>
+  <entry type="NameAttribute" style="#c17ac8"/>
+  <entry type="NameBuiltin" style="#6cb2c7"/>
+  <entry type="NameBuiltinPseudo" style="#6cb2c7"/>
+  <entry type="NameOther" style="#bdbdbd"/>
+
+  <!-- Literals -->
+  <entry type="Literal" style="#54c59f"/>
+  <entry type="LiteralDate" style="#54c59f"/>
+  <entry type="LiteralString" style="#54c59f"/>
+  <entry type="LiteralStringChar" style="#54c59f"/>
+  <entry type="LiteralStringSingle" style="#54c59f"/>
+  <entry type="LiteralStringDouble" style="#54c59f"/>
+  <entry type="LiteralStringBacktick" style="#54c59f"/>
+  <entry type="LiteralStringOther" style="#54c59f"/>
+  <entry type="LiteralStringSymbol" style="#54c59f"/>
+  <entry type="LiteralStringInterpol" style="#54c59f"/>
+  <entry type="LiteralStringAffix" style="#8464c6"/>
+  <entry type="LiteralStringDelimiter" style="#54c59f"/>
+  <entry type="LiteralStringEscape" style="#8464c6"/>
+  <entry type="LiteralStringRegex" style="#54c59f"/>
+  <entry type="LiteralStringDoc" style="#6d6d6d"/>
+  <entry type="LiteralStringHeredoc" style="#6d6d6d"/>
+  <entry type="LiteralNumber" style="#54c59f"/>
+  <entry type="LiteralNumberBin" style="#54c59f"/>
+  <entry type="LiteralNumberHex" style="#54c59f"/>
+  <entry type="LiteralNumberInteger" style="#54c59f"/>
+  <entry type="LiteralNumberFloat" style="#54c59f"/>
+  <entry type="LiteralNumberIntegerLong" style="#54c59f"/>
+  <entry type="LiteralNumberOct" style="#54c59f"/>
+
+  <!-- Operators -->
+  <entry type="Operator" style="#8464c6"/>
+  <entry type="OperatorWord" style="#8464c6"/>
+
+  <!-- Comments (italic) -->
+  <entry type="Comment" style="italic #6d6d6d"/>
+  <entry type="CommentSingle" style="italic #6d6d6d"/>
+  <entry type="CommentMultiline" style="italic #6d6d6d"/>
+  <entry type="CommentSpecial" style="italic #6d6d6d"/>
+  <entry type="CommentHashbang" style="italic #6d6d6d"/>
+  <entry type="CommentPreproc" style="italic #6d6d6d"/>
+  <entry type="CommentPreprocFile" style="italic #6d6d6d"/>
+
+  <!-- Generic -->
+  <entry type="Generic" style="#bdbdbd"/>
+  <entry type="GenericInserted" style="bg:#15141b #54c59f"/>
+  <entry type="GenericDeleted" style="bg:#15141b #c55858"/>
+  <entry type="GenericEmph" style="italic #bdbdbd"/>
+  <entry type="GenericStrong" style="bold #bdbdbd"/>
+  <entry type="GenericUnderline" style="underline #bdbdbd"/>
+  <entry type="GenericHeading" style="bold #8464c6"/>
+  <entry type="GenericSubheading" style="bold #8464c6"/>
+  <entry type="GenericOutput" style="#bdbdbd"/>
+  <entry type="GenericPrompt" style="#bdbdbd"/>
+  <entry type="GenericError" style="#c55858"/>
+  <entry type="GenericTraceback" style="#c55858"/>
+
+  <!-- Punctuation -->
+  <entry type="Punctuation" style="#bdbdbd"/>
+  <entry type="Text" style="#bdbdbd"/>
+  <entry type="TextWhitespace" style="#bdbdbd"/>
+</style>

--- a/src/ports/chroma/index.ts
+++ b/src/ports/chroma/index.ts
@@ -1,0 +1,43 @@
+import { AuraAPI } from 'core'
+import { resolve } from 'path'
+
+export async function ChromaPort(Aura: AuraAPI) {
+  const { createPort, createReadme, colorSchemes, constants } = Aura
+  const templateFolder = resolve(__dirname, 'templates')
+  const { info } = constants
+
+  const portName = 'Chroma'
+  const version = '1.0.0'
+  const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-chroma-preview.png?raw=true`
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.xml`),
+    outputFileName: `${info.slug}-dark`,
+    replacements: {
+      ...colorSchemes.dark,
+      ...info,
+      version,
+      displayName: `${info.displayName} Dark`,
+    },
+  })
+
+  await createPort({
+    template: resolve(templateFolder, `${info.slug}.xml`),
+    outputFileName: `${info.slug}-soft-dark`,
+    replacements: {
+      ...colorSchemes.darkSoft,
+      ...info,
+      version,
+      displayName: `${info.displayName} Dark Soft`,
+    },
+  })
+
+  await createReadme({
+    template: resolve(templateFolder, 'README.md'),
+    replacements: {
+      portName,
+      version,
+      previewURL,
+    },
+  })
+}

--- a/src/ports/chroma/index.ts
+++ b/src/ports/chroma/index.ts
@@ -7,7 +7,7 @@ export async function ChromaPort(Aura: AuraAPI) {
   const { info } = constants
 
   const portName = 'Chroma'
-  const version = '1.0.0'
+  const version = '1.0.1'
   const previewURL = `https://github.com/${info.author.username}/assets/blob/master/images/${info.slug}/aura-chroma-preview.png?raw=true`
 
   await createPort({

--- a/src/ports/chroma/index.ts
+++ b/src/ports/chroma/index.ts
@@ -17,17 +17,19 @@ export async function ChromaPort(Aura: AuraAPI) {
       ...colorSchemes.dark,
       ...info,
       version,
+      slug: `${info.slug}-dark`,
       displayName: `${info.displayName} Dark`,
     },
   })
 
   await createPort({
     template: resolve(templateFolder, `${info.slug}.xml`),
-    outputFileName: `${info.slug}-soft-dark`,
+    outputFileName: `${info.slug}-dark-soft`,
     replacements: {
       ...colorSchemes.darkSoft,
       ...info,
       version,
+      slug: `${info.slug}-dark-soft`,
       displayName: `${info.displayName} Dark Soft`,
     },
   })

--- a/src/ports/chroma/templates/README.md
+++ b/src/ports/chroma/templates/README.md
@@ -1,0 +1,37 @@
+{{{ basic-heading }}}
+
+# Installation
+
+Chroma is a syntax highlighter used by various applications, including static site generators like [Hugo](https://gohugo.io/), the TUI based file manager [Superfile](https://superfile.dev/), the `less` pager alternative [Moor](https://github.com/walles/moor), and others.
+
+The {{ displayName }} color scheme can be used within these applications simply by configuring their respective theme/color scheme settings to use {{ displayName }}.
+
+### Downstream updates
+
+This repo provides the template and config to generate the XML color scheme files for Chroma. Requests to include any changes or new features will require a separate PR to the Chroma [project repository](https://github.com/alecthomas/chroma) with the updated package XML files.
+
+# Contributors
+
+<table>
+  <thead>
+    <tr>
+      <td valign="bottom">
+        <p align="center">
+          <a href="https://github.com/arrrgi">
+            <img src="https://github.com/arrrgi.png?size=100" align="center" />
+          </a>
+        </p>
+      </td>
+      {{{ author-thead }}}
+    </tr>
+  </thead>
+
+  <tbody>
+    <tr>
+      <td><a href="https://github.com/arrrgi">Rowan Gillson</a></td>
+      {{{ author-tbody }}}
+    </tr>
+  </tbody>
+</table>
+
+{{{ footer }}}

--- a/src/ports/chroma/templates/aura-theme.xml
+++ b/src/ports/chroma/templates/aura-theme.xml
@@ -4,7 +4,7 @@
 # Theme version: {{ version }}
 -->
 
-<style name="{{ displayName }}">
+<style name="{{ slug }}">
   <!-- Base -->
   <entry type="Background" style="bg:{{ accent12 }} {{ accent7 }}"/>
   <entry type="CodeLine" style="{{ accent7 }}"/>

--- a/src/ports/chroma/templates/aura-theme.xml
+++ b/src/ports/chroma/templates/aura-theme.xml
@@ -1,0 +1,107 @@
+<!--
+# {{ displayName }} > Color scheme for Chroma syntax highlighter
+# Repository: {{{ repository }}}
+# Theme version: {{ version }}
+-->
+
+<style name="{{ displayName }}">
+  <!-- Base -->
+  <entry type="Background" style="bg:{{ accent12 }} {{ accent7 }}"/>
+  <entry type="CodeLine" style="{{ accent7 }}"/>
+  <entry type="Error" style="{{ accent5 }}"/>
+  <entry type="Other" style="{{ accent7 }}"/>
+  <entry type="LineTableTD" style=""/>
+  <entry type="LineTable" style=""/>
+  <entry type="LineHighlight" style="bg:{{ accent38 }}"/>
+  <entry type="LineNumbersTable" style="{{ accent8 }}"/>
+  <entry type="LineNumbers" style="{{ accent8 }}"/>
+
+  <!-- Keywords -->
+  <entry type="Keyword" style="{{ accent1 }}"/>
+  <entry type="KeywordReserved" style="{{ accent1 }}"/>
+  <entry type="KeywordPseudo" style="{{ accent1 }}"/>
+  <entry type="KeywordConstant" style="{{ accent2 }}"/>
+  <entry type="KeywordDeclaration" style="{{ accent1 }}"/>
+  <entry type="KeywordNamespace" style="{{ accent1 }}"/>
+  <entry type="KeywordType" style="{{ accent32 }}"/>
+
+  <!-- Names -->
+  <entry type="Name" style="{{ accent7 }}"/>
+  <entry type="NameClass" style="{{ accent32 }}"/>
+  <entry type="NameConstant" style="{{ accent2 }}"/>
+  <entry type="NameDecorator" style="{{ accent6 }}"/>
+  <entry type="NameEntity" style="{{ accent3 }}"/>
+  <entry type="NameException" style="{{ accent5 }}"/>
+  <entry type="NameFunction" style="{{ accent3 }}"/>
+  <entry type="NameFunctionMagic" style="{{ accent3 }}"/>
+  <entry type="NameLabel" style="{{ accent6 }}"/>
+  <entry type="NameNamespace" style="{{ accent7 }}"/>
+  <entry type="NameProperty" style="{{ accent6 }}"/>
+  <entry type="NameTag" style="{{ accent1 }}"/>
+  <entry type="NameVariable" style="{{ accent7 }}"/>
+  <entry type="NameVariableClass" style="{{ accent7 }}"/>
+  <entry type="NameVariableGlobal" style="{{ accent7 }}"/>
+  <entry type="NameVariableInstance" style="{{ accent7 }}"/>
+  <entry type="NameVariableMagic" style="{{ accent7 }}"/>
+  <entry type="NameAttribute" style="{{ accent6 }}"/>
+  <entry type="NameBuiltin" style="{{ accent32 }}"/>
+  <entry type="NameBuiltinPseudo" style="{{ accent32 }}"/>
+  <entry type="NameOther" style="{{ accent7 }}"/>
+
+  <!-- Literals -->
+  <entry type="Literal" style="{{ accent2 }}"/>
+  <entry type="LiteralDate" style="{{ accent2 }}"/>
+  <entry type="LiteralString" style="{{ accent2 }}"/>
+  <entry type="LiteralStringChar" style="{{ accent2 }}"/>
+  <entry type="LiteralStringSingle" style="{{ accent2 }}"/>
+  <entry type="LiteralStringDouble" style="{{ accent2 }}"/>
+  <entry type="LiteralStringBacktick" style="{{ accent2 }}"/>
+  <entry type="LiteralStringOther" style="{{ accent2 }}"/>
+  <entry type="LiteralStringSymbol" style="{{ accent2 }}"/>
+  <entry type="LiteralStringInterpol" style="{{ accent2 }}"/>
+  <entry type="LiteralStringAffix" style="{{ accent1 }}"/>
+  <entry type="LiteralStringDelimiter" style="{{ accent2 }}"/>
+  <entry type="LiteralStringEscape" style="{{ accent1 }}"/>
+  <entry type="LiteralStringRegex" style="{{ accent2 }}"/>
+  <entry type="LiteralStringDoc" style="{{ accent8 }}"/>
+  <entry type="LiteralStringHeredoc" style="{{ accent8 }}"/>
+  <entry type="LiteralNumber" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberBin" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberHex" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberInteger" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberFloat" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberIntegerLong" style="{{ accent2 }}"/>
+  <entry type="LiteralNumberOct" style="{{ accent2 }}"/>
+
+  <!-- Operators -->
+  <entry type="Operator" style="{{ accent1 }}"/>
+  <entry type="OperatorWord" style="{{ accent1 }}"/>
+
+  <!-- Comments (italic) -->
+  <entry type="Comment" style="italic {{ accent8 }}"/>
+  <entry type="CommentSingle" style="italic {{ accent8 }}"/>
+  <entry type="CommentMultiline" style="italic {{ accent8 }}"/>
+  <entry type="CommentSpecial" style="italic {{ accent8 }}"/>
+  <entry type="CommentHashbang" style="italic {{ accent8 }}"/>
+  <entry type="CommentPreproc" style="italic {{ accent8 }}"/>
+  <entry type="CommentPreprocFile" style="italic {{ accent8 }}"/>
+
+  <!-- Generic -->
+  <entry type="Generic" style="{{ accent7 }}"/>
+  <entry type="GenericInserted" style="bg:{{ accent12 }} {{ accent2 }}"/>
+  <entry type="GenericDeleted" style="bg:{{ accent12 }} {{ accent5 }}"/>
+  <entry type="GenericEmph" style="italic {{ accent7 }}"/>
+  <entry type="GenericStrong" style="bold {{ accent7 }}"/>
+  <entry type="GenericUnderline" style="underline {{ accent7 }}"/>
+  <entry type="GenericHeading" style="bold {{ accent1 }}"/>
+  <entry type="GenericSubheading" style="bold {{ accent1 }}"/>
+  <entry type="GenericOutput" style="{{ accent7 }}"/>
+  <entry type="GenericPrompt" style="{{ accent7 }}"/>
+  <entry type="GenericError" style="{{ accent5 }}"/>
+  <entry type="GenericTraceback" style="{{ accent5 }}"/>
+
+  <!-- Punctuation -->
+  <entry type="Punctuation" style="{{ accent7 }}"/>
+  <entry type="Text" style="{{ accent7 }}"/>
+  <entry type="TextWhitespace" style="{{ accent7 }}"/>
+</style>

--- a/src/ports/chroma/templates/aura-theme.xml
+++ b/src/ports/chroma/templates/aura-theme.xml
@@ -101,7 +101,7 @@
   <entry type="GenericTraceback" style="{{ accent5 }}"/>
 
   <!-- Punctuation -->
-  <entry type="Punctuation" style="{{ accent7 }}"/>
+  <entry type="Punctuation" style="{{ accent6 }}"/>
   <entry type="Text" style="{{ accent7 }}"/>
   <entry type="TextWhitespace" style="{{ accent7 }}"/>
 </style>


### PR DESCRIPTION
#### Description

This PR: Adds support for Chroma, a syntax highlighter written in Go used by a variety of other tools

#### Assets

<img width="1398" height="882" alt="aura-chroma-preview" src="https://github.com/user-attachments/assets/6648e6ba-d472-444e-b72d-9b8b61d117e0" />


<!--
If this PR is about a new port, you must provide:
  1. An image to the icon of the app that this port is related to
  2. A screenshot with a good zoom in fullscreen showing this port in action

If this PR is not about a new port: remove this "Assets" section 
-->

#### Checklist

<!--
Remove items that do not apply.
For completed items, change [ ] to [x].
-->

- [x] PR description included
- [x] I've read the [documents](https://github.com/daltonmenezes/aura-theme#documentation)
- [x] I've created or commented in an issue related to this port asking to work on it
- [x] I know I shouldn't change any files in the packages folder manually
- [ ] I've added this port at the end of the related category list in the [main README](https://github.com/daltonmenezes/aura-theme/blob/main/README.md)
- [ ] I've attached an image to the icon of the app that this port is related to
- [x] I've attached a screenshot with a good zoom in fullscreen showing this port in action

#### PR Submitter Notes

1. Regarding #244 - I have not added this to the Aura Theme README as it deserves it's own section
2. I also haven't included the preview in the main README as these are stored in your **'assets'** repo